### PR TITLE
feat(providers): add TestingBot cloud provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,25 @@
 # CLAUDE.md
 
-Context for Claude Code when working with this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Commands
 
 ```bash
 npm run bundle      # Build: clean + tsup + make executable + create .tgz
-npm run lint        # ESLint + TypeScript type-checking (tsc --noEmit)
-npm test            # Run unit tests (vitest + happy-dom)
+npm run lint        # ESLint (--fix) + TypeScript type-checking (tsc --noEmit)
+npm test            # Run all unit tests (vitest run; env: happy-dom)
 npm run dev         # Development server (tsx --watch) — picks up code changes automatically; rebundle only needed for npm package changes
 npm run dev:http    # Dev server with HTTP transport (for browser-based MCP clients)
 npm start           # Run built server from lib/server.js
 npm run start:http  # Built server with HTTP transport (for browser-based MCP clients)
+
+# Single test file / focused run (vitest is not exposed via an npm script):
+npx vitest run tests/tools/get-elements-tool.test.ts   # one file
+npx vitest run -t "filter pattern"                      # tests matching a name
+npx vitest tests/trace/                                 # watch mode for a directory
 ```
+
+`vitest.config.ts` sets `environment: 'happy-dom'` and typechecks tests against `tsconfig.test.json`.
 
 ## Architecture
 
@@ -27,7 +34,8 @@ src/
 │   └── cloud/
 │       ├── browserstack.provider.ts  # BrowserStack (browser + App Automate)
 │       ├── saucelabs.provider.ts     # Sauce Labs (browser + App Storage)
-│       └── testmu.provider.ts        # TestMu / LambdaTest (browser + mobile)
+│       ├── testmu.provider.ts        # TestMu / LambdaTest (browser + mobile)
+│       └── testingbot.provider.ts    # TestingBot (browser + mobile + Storage)
 ├── trace/             # Playwright-compatible trace recording (recorder.ts, tool-mapping.ts, zip-writer.ts)
 ├── tools/             # One file per MCP tool (see Tool Pattern below)
 ├── resources/         # One file per MCP resource (see Recording below)
@@ -51,7 +59,7 @@ export interface SessionMetadata {
   type: 'browser' | 'ios' | 'android';
   capabilities: Record<string, unknown>;
   isAttached: boolean;
-  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu';   // set at session start; used by lifecycle to call provider hooks
+  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot';   // set at session start; used by lifecycle to call provider hooks
   tunnelHandle?: unknown;                 // opaque handle returned by provider.startTunnel(), passed back to onSessionClose()
 }
 ```
@@ -114,13 +122,21 @@ MCP resources expose live session data — all at fixed URIs discoverable via Li
 - `wdio://session/current/app-state` — mobile app state
 - `wdio://session/current/geolocation` — device geolocation
 - `wdio://session/current/capabilities` — resolved WebDriver capabilities for the active session
-- `wdio://browserstack/local-binary` — platform-specific download URL and daemon start command for BrowserStack Local binary
+- `wdio://session/current/logs` — crash logs + browser console logs for the current session
+
+**Cloud tunnel binaries** (download URL + daemon start command):
+- `wdio://browserstack/local-binary`
+- `wdio://saucelabs/local-binary`
+- `wdio://testmu/local-binary`
+- `wdio://testingbot/local-binary` (single cross-platform Java JAR, requires Java 11+)
 
 ### Build
 
 - **tsup** bundles `src/server.ts` → `lib/server.js` (ESM)
 - Shebang preserved for CLI execution
 - `zod` externalized
+- Two `bin` entries: `wdio-mcp` (the server) and `wdio-show-trace` (`src/show-trace.ts` — inspect a recorded trace)
+- Package subpath exports: `.` (server), `./snapshot` (`src/snapshot.ts`), `./trace` (`src/trace.ts`)
 
 ## Key Files
 
@@ -132,10 +148,11 @@ MCP resources expose live session data — all at fixed URIs discoverable via Li
 | `src/providers/registry.ts`                        | `getProvider()` — routes to local or cloud provider |
 | `src/providers/types.ts`                           | `SessionProvider` interface — `startTunnel()`, `onSessionClose()` lifecycle hooks |
 | `src/providers/cloud/browserstack.provider.ts`     | BrowserStack provider — tunnel lifecycle + session result marking via `onSessionClose()` |
+| `src/providers/cloud/testingbot.provider.ts`       | TestingBot provider — `tb:options` caps, single hub, form-encoded `test[success]` result marking, JAR tunnel via `testingbot-tunnel-launcher` |
 | `src/tools/session.tool.ts`                        | `start_session` (browser + mobile), `close_session` |
 | `src/tools/get-elements.tool.ts`                   | `get_elements` — all elements with filtering + pagination |
-| `src/tools/browserstack.tool.ts`                   | `list_apps`, `upload_app` — BrowserStack App Automate |
-| `src/resources/`                                   | All MCP resource definitions (12 files)       |
+| `src/tools/cloud-provider.tool.ts`                 | `list_apps`, `upload_app` — generalized across BrowserStack / Sauce Labs / TestMu (registered in `server.ts`) |
+| `src/resources/`                                   | All MCP resource definitions (one per URI)    |
 | `src/scripts/get-interactable-browser-elements.ts` | Browser-context element detection             |
 | `src/locators/`                                    | Mobile element detection + locator generation |
 | `src/recording/step-recorder.ts`                   | `withRecording(toolName, cb)` HOF — wraps tools for step logging |
@@ -221,12 +238,14 @@ catch (e) {
 | `SAUCE_ACCESS_KEY` | Sauce Labs sessions + App Storage tools |
 | `TESTMU_USERNAME` | TestMu / LambdaTest sessions + tools |
 | `TESTMU_ACCESS_KEY` | TestMu / LambdaTest sessions + tools |
+| `TESTINGBOT_KEY` | TestingBot sessions + tools |
+| `TESTINGBOT_SECRET` | TestingBot sessions + tools |
 
 ## Planned Improvements
 
 See `docs/architecture/` for proposals:
 
-- `session-configuration-proposal.md` — Cloud provider pattern — BrowserStack, SauceLabs, and TestMu implemented; `providers/registry.ts` + `providers/cloud/` is the extension point for new providers
+- `session-configuration-proposal.md` — Cloud provider pattern — BrowserStack, SauceLabs, TestMu, and TestingBot implemented; `providers/registry.ts` + `providers/cloud/` is the extension point for new providers
 - `multi-session-proposal.md` — Parallel sessions for sub-agent coordination
 - `interaction-sequencing-proposal.md` — Sequencing model for tool interactions
 - `trace-recording-and-replay.md` — Playwright-compatible trace recording (implemented in `src/trace/`)

--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ appium
 ## Cloud Providers
 
 Run browser and mobile app tests on cloud real devices and browsers without any local setup. Currently supports
-[BrowserStack](https://www.browserstack.com/), [Sauce Labs](https://saucelabs.com/), and
-[LambdaTest](https://www.lambdatest.com/).
+[BrowserStack](https://www.browserstack.com/), [Sauce Labs](https://saucelabs.com/),
+[LambdaTest](https://www.lambdatest.com/), and [TestingBot](https://testingbot.com/).
 
 ### Prerequisites
 
@@ -356,6 +356,34 @@ export TESTMU_ACCESS_KEY=your_access_key
 
 </details>
 
+<details>
+<summary>TestingBot</summary>
+
+```bash
+export TESTINGBOT_KEY=your_key
+export TESTINGBOT_SECRET=your_secret
+```
+
+```json
+{
+  "mcpServers": {
+    "wdio-mcp": {
+      "command": "npx",
+      "args": ["-y", "@wdio/mcp@latest"],
+      "env": {
+        "TESTINGBOT_KEY": "your_key",
+        "TESTINGBOT_SECRET": "your_secret"
+      }
+    }
+  }
+}
+```
+
+| `TESTINGBOT_KEY` | TestingBot key (required) |
+| `TESTINGBOT_SECRET` | TestingBot secret (required) |
+
+</details>
+
 ### Browser Sessions
 
 Run a browser on a specific OS/version combination:
@@ -403,11 +431,24 @@ start_session({
         session: 'Login flow'
     }
 })
+
+// TestingBot
+start_session({
+    provider: 'testingbot',
+    platform: 'browser',
+    browser: 'chrome',
+    os: 'Windows',               // combined with osVersion → platformName (default: Windows 11)
+    osVersion: '11',
+    reporting: {
+        build: 'v1.2.0',
+        session: 'Login flow'
+    }
+})
 ```
 
 > **Provider-specific `os` / `osVersion` behavior:**
 > - **BrowserStack** — `os` and `osVersion` map to separate `bstack:options.os` / `bstack:options.osVersion` fields.
-> - **Sauce Labs / LambdaTest** — `os` and `osVersion` are combined into the W3C `platformName` capability (e.g., `os: 'Windows'` + `osVersion: '11'` → `platformName: 'Windows 11'`). Both providers use `platformName` values like `"Windows 11"`, `"MacOS Sequoia"`, or `"Linux"`.
+> - **Sauce Labs / LambdaTest / TestingBot** — `os` and `osVersion` are combined into the W3C `platformName` capability (e.g., `os: 'Windows'` + `osVersion: '11'` → `platformName: 'Windows 11'`). These providers use `platformName` values like `"Windows 11"`, `"MacOS Sequoia"`, or `"Linux"`. TestingBot defaults to `Windows 11` when `os` is omitted.
 
 ### Mobile App Sessions
 
@@ -422,6 +463,9 @@ upload_app({ provider: 'saucelabs', path: '/path/to/app.apk' })
 
 // LambdaTest: returns lt:// URL
 upload_app({ provider: 'testmu', path: '/path/to/app.apk' })
+
+// TestingBot: returns tb:// URL
+upload_app({ provider: 'testingbot', path: '/path/to/app.apk' })
 
 // Start a session
 start_session({
@@ -446,6 +490,15 @@ start_session({
     provider: 'testmu',
     platform: 'android',
     app: 'lt://abc123...',
+    deviceName: 'Pixel 7',
+    platformVersion: '13'
+})
+
+// TestingBot native app
+start_session({
+    provider: 'testingbot',
+    platform: 'android',
+    app: 'tb://abc123...',
     deviceName: 'Pixel 7',
     platformVersion: '13'
 })
@@ -483,6 +536,15 @@ start_session({
     deviceName: 'Pixel 7',
     platformVersion: '13'
 })
+
+// TestingBot — Chrome on Android emulator
+start_session({
+    provider: 'testingbot',
+    platform: 'android',
+    browser: 'chrome',
+    deviceName: 'Pixel 7',
+    platformVersion: '13'
+})
 ```
 
 > **Note:** Mobile browser sessions do not require `app`, `appPath`, or `noReset`. The provider launches a browser on the emulator directly.
@@ -493,6 +555,7 @@ Use `list_apps` to see previously uploaded apps:
 list_apps({ provider: 'browserstack' })
 list_apps({ provider: 'saucelabs', sortBy: 'app_name' })
 list_apps({ provider: 'testmu' })
+list_apps({ provider: 'testingbot' })
 list_apps({ provider: 'browserstack', organizationWide: true })
 ```
 
@@ -518,7 +581,7 @@ start_session({
 
 The `tunnel` parameter replaces the deprecated `browserstackLocal`, `saucelabsLocal`, and `testmuLocal` params. Set it to `true` to auto-start the tunnel (stopped automatically after the session), or `'external'` to use a tunnel already running on your machine.
 
-> **Note**: Sauce Connect and TestMu Tunnel require their respective binaries. The `wdio://saucelabs/local-binary` and `wdio://testmu/local-binary` resources provide platform-specific download URLs and setup instructions.
+> **Note**: With `tunnel: true` the provider downloads and manages the tunnel binary for you. For `tunnel: 'external'` you run it yourself — the `wdio://saucelabs/local-binary`, `wdio://testmu/local-binary`, and `wdio://testingbot/local-binary` resources provide download URLs and setup instructions. The TestingBot Tunnel is a single cross-platform Java JAR (requires Java 11+) rather than a per-platform binary.
 
 ### Reporting Labels
 
@@ -537,7 +600,7 @@ All session types support `reporting` labels that appear in the provider dashboa
 | `upload_app` | Upload a local `.apk` or `.ipa` to the provider; returns an app URL/reference |
 | `list_apps`  | List apps previously uploaded to the provider's app storage                   |
 
-Both tools require a `provider` parameter (`'browserstack'`, `'saucelabs'`, or `'testmu'`).
+Both tools require a `provider` parameter (`'browserstack'`, `'saucelabs'`, `'testmu'`, or `'testingbot'`).
 
 ## Features
 
@@ -650,6 +713,7 @@ Both tools require a `provider` parameter (`'browserstack'`, `'saucelabs'`, or `
 | `wdio://browserstack/local-binary`            | BrowserStack Local binary download URL and start command |
 | `wdio://saucelabs/local-binary`               | Sauce Connect binary download URL and start command      |
 | `wdio://testmu/local-binary`                  | TestMu Tunnel binary download URL and start command       |
+| `wdio://testingbot/local-binary`              | TestingBot Tunnel JAR download URL and start command (Java 11+) |
 
 ## Usage Examples
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "puppeteer-core": "^24.40.0",
     "saucelabs": "^9.0.2",
     "sharp": "^0.34.5",
+    "testingbot-tunnel-launcher": "^1.1.18",
     "webdriverio": "^9.27.0",
     "xpath": "^0.0.34",
     "yazl": "^3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      testingbot-tunnel-launcher:
+        specifier: ^1.1.18
+        version: 1.1.18
       webdriverio:
         specifier: ^9.27.0
         version: 9.27.1(puppeteer-core@24.43.1)
@@ -3719,6 +3722,10 @@ packages:
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  testingbot-tunnel-launcher@1.1.18:
+    resolution: {integrity: sha512-0xSA7r/RsW4ltxrviDaIDAEevEZDbTq0E8vFPfxjOPBfo8aTee0rMAqgGTsYnTP0St4rTfosdgS/0aRLEzCEHw==}
+    engines: {node: '>=18'}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -7823,6 +7830,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  testingbot-tunnel-launcher@1.1.18: {}
 
   text-decoder@1.2.7:
     dependencies:

--- a/src/providers/cloud/testingbot.provider.ts
+++ b/src/providers/cloud/testingbot.provider.ts
@@ -1,0 +1,166 @@
+import { basicAuth } from '../../utils/auth';
+import type { ConnectionConfig, SessionProvider, SessionResult } from '../types';
+import type { Browser as WdioBrowser } from 'webdriverio';
+import testingbotTunnel from 'testingbot-tunnel-launcher';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export class TestingBotProvider implements SessionProvider {
+  name = 'testingbot';
+
+  getConnectionConfig(_options: Record<string, unknown>): ConnectionConfig {
+    // TestingBot uses a single hub for both browser and mobile (Appium) sessions.
+    return {
+      protocol: 'https',
+      hostname: 'hub.testingbot.com',
+      port: 443,
+      path: '/wd/hub',
+      user: process.env.TESTINGBOT_KEY,
+      key: process.env.TESTINGBOT_SECRET,
+    };
+  }
+
+  buildCapabilities(options: Record<string, unknown>): Record<string, unknown> {
+    const platform = options.platform as string;
+    const userCapabilities = (options.capabilities as Record<string, unknown> | undefined) ?? {};
+    const tunnel = (options.tunnel ?? options.testingbotLocal) as boolean | string | undefined;
+    const reporting = options.reporting as { project?: string; build?: string; session?: string } | undefined;
+
+    const tbOptions: Record<string, unknown> = {};
+
+    if (reporting?.build) tbOptions.build = reporting.build;
+    if (reporting?.session) tbOptions.name = reporting.session;
+    else if (reporting?.project) tbOptions.name = reporting.project;
+
+    if (tunnel) {
+      tbOptions.tunnel = true;
+      if (options.tunnelName) tbOptions.tunnelIdentifier = options.tunnelName;
+    }
+
+    if (platform === 'browser') {
+      return {
+        ...userCapabilities,
+        browserName: (options.browser as string | undefined) ?? 'chrome',
+        browserVersion: (options.browserVersion as string | undefined) ?? 'latest',
+        platformName: options.os ? [options.os as string, options.osVersion as string | undefined].filter(Boolean).join(' ') : 'Windows 11',
+        'tb:options': tbOptions,
+      };
+    }
+
+    // Mobile (ios / android)
+    const mobileBrowser = options.browser as string | undefined;
+
+    // Mobile browser/emulator mode (e.g. Chrome on Android emulator)
+    if (mobileBrowser) {
+      const caps: Record<string, unknown> = {
+        platformName: platform,
+        browserName: mobileBrowser,
+        'appium:deviceName': options.deviceName,
+        'appium:platformVersion': options.platformVersion,
+        'appium:automationName': (options.automationName as string | undefined) ?? (platform === 'ios' ? 'XCUITest' : 'UiAutomator2'),
+        'appium:newCommandTimeout': (options.newCommandTimeout as number | undefined) ?? 300,
+        'tb:options': tbOptions,
+      };
+      return { ...userCapabilities, ...caps };
+    }
+
+    // Mobile native app mode
+    const autoAcceptAlerts = options.autoAcceptAlerts as boolean | undefined;
+    const autoDismissAlerts = options.autoDismissAlerts as boolean | undefined;
+
+    const caps: Record<string, unknown> = {
+      platformName: platform,
+      'appium:app': options.app,
+      'appium:deviceName': options.deviceName,
+      'appium:platformVersion': options.platformVersion,
+      'appium:automationName': (options.automationName as string | undefined) ?? (platform === 'ios' ? 'XCUITest' : 'UiAutomator2'),
+      'appium:autoGrantPermissions': (options.autoGrantPermissions as boolean | undefined) ?? true,
+      'appium:autoAcceptAlerts': autoDismissAlerts ? undefined : (autoAcceptAlerts ?? true),
+      'appium:autoDismissAlerts': autoDismissAlerts,
+      'appium:newCommandTimeout': (options.newCommandTimeout as number | undefined) ?? 300,
+      'tb:options': tbOptions,
+    };
+
+    return { ...userCapabilities, ...caps };
+  }
+
+  getSessionType(options: Record<string, unknown>): 'browser' | 'ios' | 'android' {
+    const platform = options.platform as string;
+    if (platform === 'browser') return 'browser';
+    return platform as 'ios' | 'android';
+  }
+
+  shouldAutoDetach(_options: Record<string, unknown>): boolean {
+    return false;
+  }
+
+  async startTunnel(options: Record<string, unknown>): Promise<unknown> {
+    const tunnelName = (options.tunnelName as string | undefined) ?? `wdio-mcp-testingbot-${Date.now()}`;
+    const logfile = join(tmpdir(), 'testingbot-tunnel.log');
+    console.error(`[TestingBot] Starting tunnel "${tunnelName}"`);
+    try {
+      const tunnel = await testingbotTunnel.downloadAndRunAsync({
+        apiKey: process.env.TESTINGBOT_KEY ?? '',
+        apiSecret: process.env.TESTINGBOT_SECRET ?? '',
+        tunnelIdentifier: tunnelName,
+        logfile,
+      });
+      console.error(`[TestingBot] Tunnel started: "${tunnelName}"`);
+      return tunnel;
+    } catch (e: unknown) {
+      const msg = (e !== null && typeof e === 'object' ? (e as { message?: string }).message : undefined) ?? String(e);
+      if (msg.includes('already running') || msg.includes('another tunnel') || msg.includes('already in use')) {
+        console.error('[TestingBot] Tunnel already running — reusing existing tunnel');
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  async onSessionClose(
+    sessionId: string,
+    _sessionType: 'browser' | 'ios' | 'android',
+    result: SessionResult,
+    _tunnelHandle?: unknown,
+    _browser?: WdioBrowser,
+    _region?: string,
+  ): Promise<void> {
+    const key = process.env.TESTINGBOT_KEY;
+    const secret = process.env.TESTINGBOT_SECRET;
+    if (!key || !secret) return;
+
+    // The :id route accepts the WebDriver session UUID for both web and mobile.
+    try {
+      const auth = basicAuth(key, secret);
+      const params = new URLSearchParams();
+      params.set('test[success]', result.status === 'passed' ? '1' : '0');
+      if (result.reason) params.set('test[status_message]', result.reason);
+      const apiUrl = `https://api.testingbot.com/v1/tests/${sessionId}`;
+      console.error(`[TestingBot] Setting test status for ${sessionId}: ${result.status}`);
+      const res = await fetch(apiUrl, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Basic ${auth}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: params.toString(),
+      });
+      if (res.ok) {
+        console.error('[TestingBot] Test status set successfully via REST API');
+      } else {
+        const resBody = await res.text();
+        console.error(`[TestingBot] Failed to set test status: HTTP ${res.status} — ${resBody}`);
+      }
+    } catch (e) {
+      console.error('[TestingBot] Failed to set test status via REST API:', e);
+    }
+  }
+
+  async stopTunnel(tunnelHandle?: unknown): Promise<void> {
+    if (!tunnelHandle) return;
+    const tunnel = tunnelHandle as { close?: (cb: () => void) => void };
+    await (typeof tunnel.close === 'function' ? new Promise<void>((resolve) => tunnel.close(() => resolve())) : testingbotTunnel.killAsync());
+  }
+}
+
+export const testingBotProvider = new TestingBotProvider();

--- a/src/providers/cloud/testingbot.provider.ts
+++ b/src/providers/cloud/testingbot.provider.ts
@@ -158,8 +158,12 @@ export class TestingBotProvider implements SessionProvider {
 
   async stopTunnel(tunnelHandle?: unknown): Promise<void> {
     if (!tunnelHandle) return;
-    const tunnel = tunnelHandle as { close?: (cb: () => void) => void };
-    await (typeof tunnel.close === 'function' ? new Promise<void>((resolve) => tunnel.close(() => resolve())) : testingbotTunnel.killAsync());
+    const close = (tunnelHandle as { close?: (cb: () => void) => void }).close;
+    if (typeof close !== 'function') {
+      console.error('[TestingBot] Tunnel handle has no close() method — skipping stop');
+      return;
+    }
+    await new Promise<void>((resolve) => close(() => resolve()));
   }
 }
 

--- a/src/providers/cloud/testingbot.provider.ts
+++ b/src/providers/cloud/testingbot.provider.ts
@@ -108,8 +108,8 @@ export class TestingBotProvider implements SessionProvider {
       console.error(`[TestingBot] Tunnel started: "${tunnelName}"`);
       return tunnel;
     } catch (e: unknown) {
-      const msg = (e !== null && typeof e === 'object' ? (e as { message?: string }).message : undefined) ?? String(e);
-      if (msg.includes('already running') || msg.includes('another tunnel') || msg.includes('already in use')) {
+      const msg = ((e !== null && typeof e === 'object' ? (e as { message?: string }).message : undefined) ?? String(e)).toLowerCase();
+      if (msg.includes('already running') || msg.includes('another tunnel') || msg.includes('already in use') || msg.includes('already active')) {
         console.error('[TestingBot] Tunnel already running — reusing existing tunnel');
         return null;
       }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -4,11 +4,13 @@ import { localAppiumProvider } from './local-appium.provider';
 import { browserStackProvider } from './cloud/browserstack.provider';
 import { sauceLabsProvider } from './cloud/saucelabs.provider';
 import { testMuProvider } from './cloud/testmu.provider';
+import { testingBotProvider } from './cloud/testingbot.provider';
 
 const providers = new Map<string, SessionProvider>([
   ['browserstack', browserStackProvider],
   ['saucelabs', sauceLabsProvider],
   ['testmu', testMuProvider],
+  ['testingbot', testingBotProvider],
 ]);
 
 function getDefaultProvider(platform: string): SessionProvider {

--- a/src/recording/code-generator.ts
+++ b/src/recording/code-generator.ts
@@ -36,6 +36,7 @@ function generateStep(step: RecordedStep, history: SessionHistory): string {
       const isBrowserStack = 'bstack:options' in history.capabilities;
       const isSauceLabs = 'sauce:options' in history.capabilities;
       const isLambdaTest = 'lt:options' in history.capabilities;
+      const isTestingBot = 'tb:options' in history.capabilities;
       const capJson = indentJson(history.capabilities)
         .split('\n')
         .map((line, i) => (i > 0 ? `  ${line}` : line))
@@ -93,6 +94,24 @@ function generateStep(step: RecordedStep, history: SessionHistory): string {
           "  path: '/wd/hub',",
           '  user: process.env.TESTMU_USERNAME,',
           '  key: process.env.TESTMU_ACCESS_KEY,',
+          `  capabilities: ${capJson}`,
+          `});${nav}`,
+        ].join('\n');
+      }
+
+      if (isTestingBot) {
+        const nav =
+          platform === 'browser' && p.navigationUrl
+            ? `\nawait browser.url('${escapeStr(p.navigationUrl)}');`
+            : '';
+        return [
+          'const browser = await remote({',
+          "  protocol: 'https',",
+          "  hostname: 'hub.testingbot.com',",
+          '  port: 443,',
+          "  path: '/wd/hub',",
+          '  user: process.env.TESTINGBOT_KEY,',
+          '  key: process.env.TESTINGBOT_SECRET,',
           `  capabilities: ${capJson}`,
           `});${nav}`,
         ].join('\n');
@@ -164,12 +183,15 @@ export function generateCode(history: SessionHistory): string {
   const bstackOptions = history.capabilities['bstack:options'] as Record<string, unknown> | undefined;
   const sauceOptions = history.capabilities['sauce:options'] as Record<string, unknown> | undefined;
   const ltOptions = history.capabilities['lt:options'] as Record<string, unknown> | undefined;
+  const tbOptions = history.capabilities['tb:options'] as Record<string, unknown> | undefined;
   const isBrowserStack = bstackOptions !== undefined;
   const isSauceLabs = sauceOptions !== undefined;
   const isLambdaTest = ltOptions !== undefined;
+  const isTestingBot = tbOptions !== undefined;
   const usesLocalTunnel = isBrowserStack ? bstackOptions?.local === true
     : isSauceLabs ? (sauceOptions?.tunnelName !== undefined)
-      : (ltOptions?.tunnel === true);
+      : isLambdaTest ? (ltOptions?.tunnel === true)
+        : (tbOptions?.tunnel === true);
 
   const steps = history.steps
     .map(step => generateStep(step, history))
@@ -340,6 +362,63 @@ export function generateCode(history: SessionHistory): string {
       preamble,
       'try {',
       ltSteps,
+      catchBlock,
+      '} finally {',
+      ...finallyLines,
+      '}',
+    ].join('\n');
+  }
+
+  if (isTestingBot) {
+    const tbSteps = steps.replace(/const browser = await remote\(/g, 'browser = await remote(');
+    const preamble = 'let browser;\nlet tbStatus = \'passed\';';
+    const catchBlock = '} catch (e) {\n  tbStatus = \'failed\';\n  throw e;';
+    const statusUpdate = [
+      "    const tbAuth = Buffer.from(`${process.env.TESTINGBOT_KEY}:${process.env.TESTINGBOT_SECRET}`).toString('base64');",
+      "    await fetch('https://api.testingbot.com/v1/tests/' + browser.sessionId, {",
+      "      method: 'PUT',",
+      "      headers: { Authorization: 'Basic ' + tbAuth, 'Content-Type': 'application/x-www-form-urlencoded' },",
+      "      body: 'test[success]=' + (tbStatus === 'passed' ? '1' : '0')",
+      '    });',
+    ].join('\n');
+    const finallyLines = [
+      '  if (browser) {',
+      statusUpdate,
+      '    await browser.deleteSession();',
+      '  }',
+    ];
+
+    if (usesLocalTunnel) {
+      const tunnelName = (tbOptions?.tunnelIdentifier as string) ?? 'wdio-mcp-tunnel';
+      const tunnelSetup = [
+        '',
+        "import testingbotTunnel from 'testingbot-tunnel-launcher';",
+        '',
+        `const tunnel = await testingbotTunnel.downloadAndRunAsync({ apiKey: process.env.TESTINGBOT_KEY, apiSecret: process.env.TESTINGBOT_SECRET, tunnelIdentifier: '${escapeStr(tunnelName)}' });`,
+        'const stopTunnel = () => testingbotTunnel.killAsync();',
+        '',
+      ].join('\n');
+
+      return [
+        "import { remote } from 'webdriverio';",
+        tunnelSetup,
+        preamble,
+        'try {',
+        tbSteps,
+        catchBlock,
+        '} finally {',
+        ...finallyLines,
+        '  await stopTunnel();',
+        '}',
+      ].join('\n');
+    }
+
+    return [
+      "import { remote } from 'webdriverio';",
+      '',
+      preamble,
+      'try {',
+      tbSteps,
       catchBlock,
       '} finally {',
       ...finallyLines,

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -2,6 +2,7 @@ export * from './session-logs.resource';
 export * from './browserstack-local.resource';
 export * from './saucelabs-local.resource';
 export * from './testmu-local.resource';
+export * from './testingbot-local.resource';
 export * from './sessions.resource';
 export * from './capabilities.resource';
 export * from './elements.resource';

--- a/src/resources/testingbot-local.resource.ts
+++ b/src/resources/testingbot-local.resource.ts
@@ -1,0 +1,40 @@
+import type { ResourceDefinition } from '../types/resource';
+
+// TestingBot Tunnel is distributed as a single cross-platform Java JAR (requires Java 11+),
+// not per-platform native binaries like the other providers.
+const DOWNLOAD_URL = 'https://testingbot.com/downloads/testingbot-tunnel.zip';
+const JAR_NAME = 'testingbot-tunnel.jar';
+
+export const testingbotLocalBinaryResource: ResourceDefinition = {
+  name: 'testingbot-local-binary',
+  uri: 'wdio://testingbot/local-binary',
+  description: 'TestingBot Tunnel download URL and daemon setup instructions. The tunnel is a single cross-platform Java JAR (requires Java 11+). MUST be read and followed before using tunnel: "external" in start_session with provider: testingbot.',
+  handler: async () => {
+    const key = process.env.TESTINGBOT_KEY ?? '<TESTINGBOT_KEY>';
+    const secret = process.env.TESTINGBOT_SECRET ?? '<TESTINGBOT_SECRET>';
+
+    const content = {
+      requirement: 'MUST start the TestingBot Tunnel BEFORE calling start_session with tunnel: "external". Without it, all navigation to local/internal URLs will fail. (Use tunnel: true to let the provider auto-start it instead.)',
+      runtime: 'Java 11+ (17 LTS recommended) — the tunnel is a single cross-platform JAR, no per-platform binary.',
+      downloadUrl: DOWNLOAD_URL,
+      setup: [
+        `1. Download: curl -O ${DOWNLOAD_URL}`,
+        '2. Unzip: unzip testingbot-tunnel.zip',
+        `3. Start: java -jar ${JAR_NAME} ${key} ${secret}`,
+      ],
+      commands: {
+        start: `java -jar ${JAR_NAME} ${key} ${secret}`,
+        stop: 'Press Ctrl+C in the tunnel terminal, or kill the java process.',
+      },
+      afterTunnelIsRunning: 'Call start_session with tunnel: "external" and provider: testingbot to route TestingBot traffic through the tunnel.',
+    };
+
+    return {
+      contents: [{
+        uri: 'wdio://testingbot/local-binary',
+        mimeType: 'application/json',
+        text: JSON.stringify(content, null, 2),
+      }],
+    };
+  },
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,7 @@ import {
   sessionLogsResource,
   saucelabsLocalBinaryResource,
   testmuLocalBinaryResource,
+  testingbotLocalBinaryResource,
   capabilitiesResource,
   contextResource,
   contextsResource,
@@ -177,6 +178,7 @@ function createServer(): McpServer {
   registerResource(browserstackLocalBinaryResource);
   registerResource(saucelabsLocalBinaryResource);
   registerResource(testmuLocalBinaryResource);
+  registerResource(testingbotLocalBinaryResource);
   registerResource(capabilitiesResource);
   registerResource(elementsResource);
   registerResource(accessibilityResource);

--- a/src/session/state.ts
+++ b/src/session/state.ts
@@ -4,7 +4,7 @@ export interface SessionMetadata {
   type: 'browser' | 'ios' | 'android';
   capabilities: Record<string, unknown>;
   isAttached: boolean;
-  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu';
+  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot';
   region?: string;
   tunnelName?: string;
   tunnelHandle?: unknown;

--- a/src/tools/cloud-provider.tool.ts
+++ b/src/tools/cloud-provider.tool.ts
@@ -117,6 +117,29 @@ const PROVIDER_CONFIGS: Record<string, ProviderApiConfig> = {
       return { appRef: ref, appName: data.name ?? fileName };
     },
   },
+  testingbot: {
+    name: 'TestingBot',
+    apiBase: 'https://api.testingbot.com',
+    credsEnvNames: ['TESTINGBOT_KEY', 'TESTINGBOT_SECRET'],
+    listPath: '/v1/storage',
+    supportsOrgWide: false,
+    parseListResponse: (raw) => {
+      // TestingBot returns { data: [{ app_url, filename, type, version, created_at }] }
+      const data = raw as { data?: Record<string, unknown>[] };
+      const apps = data.data ?? (Array.isArray(raw) ? raw as Record<string, unknown>[] : []);
+      return apps.map((a) => ({
+        name: (a.filename ?? a.name ?? 'unknown') as string,
+        ref: `${a.app_url}`,
+        uploadedAt: a.created_at as string | undefined,
+      }));
+    },
+    uploadPath: '/v1/storage',
+    uploadField: 'file',
+    parseUploadResponse: (raw, fileName) => {
+      const data = raw as { app_url?: string };
+      return { appRef: data.app_url ?? 'unknown', appName: fileName };
+    },
+  },
 };
 
 function getProviderConfig(provider: string, region?: string): { config: ProviderApiConfig; auth: string } | { error: string } {
@@ -140,10 +163,10 @@ function getProviderConfig(provider: string, region?: string): { config: Provide
 
 export const listAppsToolDefinition: ToolDefinition = {
   name: 'list_apps',
-  description: 'List apps uploaded to a cloud provider (BrowserStack App Automate, Sauce Labs App Storage, or TestMu Real Device Cloud). Reads provider-specific credentials from environment.',
+  description: 'List apps uploaded to a cloud provider (BrowserStack App Automate, Sauce Labs App Storage, TestMu Real Device Cloud, or TestingBot Storage). Reads provider-specific credentials from environment.',
   annotations: { title: 'List Cloud Provider Apps', readOnlyHint: true, idempotentHint: true },
   inputSchema: {
-    provider: z.enum(['browserstack', 'saucelabs', 'testmu']).describe('Cloud provider'),
+    provider: z.enum(['browserstack', 'saucelabs', 'testmu', 'testingbot']).describe('Cloud provider'),
     sortBy: z.enum(['app_name', 'uploaded_at']).optional().default('uploaded_at').describe('Sort order for results'),
     organizationWide: coerceBoolean.optional().default(false).describe('(BrowserStack only) List apps uploaded by all users in the organization. Defaults to false (own uploads only).'),
     limit: z.number().int().min(1).optional().default(20).describe('Maximum number of apps to return (only applies when organizationWide is true, default 20)'),
@@ -152,7 +175,7 @@ export const listAppsToolDefinition: ToolDefinition = {
 };
 
 type ListAppsArgs = {
-  provider: 'browserstack' | 'saucelabs' | 'testmu';
+  provider: 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot';
   sortBy?: 'app_name' | 'uploaded_at';
   organizationWide?: boolean;
   limit?: number;
@@ -223,10 +246,10 @@ export const listAppsTool: ToolCallback = async (args: ListAppsArgs) => {
 
 export const uploadAppToolDefinition: ToolDefinition = {
   name: 'upload_app',
-  description: 'Upload a local .apk or .ipa to a cloud provider (BrowserStack, Sauce Labs, or TestMu). Returns the app URL for use in start_session.',
+  description: 'Upload a local .apk or .ipa to a cloud provider (BrowserStack, Sauce Labs, TestMu, or TestingBot). Returns the app URL for use in start_session.',
   annotations: { title: 'Upload App to Cloud Provider', destructiveHint: false },
   inputSchema: {
-    provider: z.enum(['browserstack', 'saucelabs', 'testmu']).describe('Cloud provider'),
+    provider: z.enum(['browserstack', 'saucelabs', 'testmu', 'testingbot']).describe('Cloud provider'),
     path: z.string().describe('Absolute path to the .apk or .ipa file'),
     customId: z.string().optional().describe('Optional custom ID for the app (used to reference it later)'),
     region: z.enum(['us-west-1', 'eu-central-1', 'apac-southeast-1']).optional().default('eu-central-1').describe('Sauce Labs region (default: eu-central-1)'),
@@ -234,7 +257,7 @@ export const uploadAppToolDefinition: ToolDefinition = {
 };
 
 type UploadAppArgs = {
-  provider: 'browserstack' | 'saucelabs' | 'testmu';
+  provider: 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot';
   path: string;
   customId?: string;
   region?: 'us-west-1' | 'eu-central-1' | 'apac-southeast-1';

--- a/src/tools/cloud-provider.tool.ts
+++ b/src/tools/cloud-provider.tool.ts
@@ -129,7 +129,7 @@ const PROVIDER_CONFIGS: Record<string, ProviderApiConfig> = {
       const apps = data.data ?? (Array.isArray(raw) ? raw as Record<string, unknown>[] : []);
       return apps.map((a) => ({
         name: (a.filename ?? a.name ?? 'unknown') as string,
-        ref: `${a.app_url}`,
+        ref: (a.app_url as string | undefined) ?? 'unknown',
         uploadedAt: a.created_at as string | undefined,
       }));
     },

--- a/src/tools/session.tool.ts
+++ b/src/tools/session.tool.ts
@@ -19,13 +19,13 @@ export const startSessionToolDefinition: ToolDefinition = {
   description: 'Starts a browser or mobile automation session. Only one active session at a time — starting a new one closes the existing session first. Use platform "browser" with a browser name, or "ios"/"android" with deviceName. Set attach: true to connect to a running Chrome via CDP instead of launching a new browser.',
   annotations: { title: 'Start Session', destructiveHint: false },
   inputSchema: {
-    provider: z.enum(['local', 'browserstack', 'saucelabs', 'testmu']).optional().default('local').describe('Session provider (default: local)'),
+    provider: z.enum(['local', 'browserstack', 'saucelabs', 'testmu', 'testingbot']).optional().default('local').describe('Session provider (default: local)'),
     platform: platformEnum.describe('Session platform type'),
     browser: browserEnum.optional().describe('Browser to launch (required for browser platform)'),
     browserVersion: z.string().optional().describe('Browser version (cloud providers only, default: latest)'),
-    os: z.string().optional().describe('Operating system for cloud provider browser sessions (e.g. "Windows", "Mac", "macOS", "Linux"). BrowserStack: sets bstack:options.os separately. TestMu/Sauce Labs: combined with osVersion into W3C platformName. Browser platform only.'),
-    osVersion: z.string().optional().describe('OS version for cloud provider browser sessions (e.g. "11", "15", "Monterey"). BrowserStack: sets bstack:options.osVersion separately. TestMu/Sauce Labs: combined with os into W3C platformName. Browser platform only.'),
-    app: z.string().optional().describe('App URL (bs://... for BrowserStack, storage:filename= for Sauce Labs, lt://... for TestMu mobile sessions)'),
+    os: z.string().optional().describe('Operating system for cloud provider browser sessions (e.g. "Windows", "Mac", "macOS", "Linux"). BrowserStack: sets bstack:options.os separately. TestMu/Sauce Labs/TestingBot: combined with osVersion into W3C platformName. Browser platform only.'),
+    osVersion: z.string().optional().describe('OS version for cloud provider browser sessions (e.g. "11", "15", "Monterey"). BrowserStack: sets bstack:options.osVersion separately. TestMu/Sauce Labs/TestingBot: combined with os into W3C platformName. Browser platform only.'),
+    app: z.string().optional().describe('App URL (bs://... for BrowserStack, storage:filename= for Sauce Labs, lt://... for TestMu, tb://... for TestingBot mobile sessions)'),
     reporting: z.object({
       project: z.string().optional(),
       build: z.string().optional(),
@@ -70,7 +70,7 @@ export const startSessionToolDefinition: ToolDefinition = {
 };
 
 type StartSessionArgs = {
-  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu';
+  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot';
   platform: 'browser' | 'ios' | 'android';
   browser?: 'chrome' | 'firefox' | 'edge' | 'safari';
   browserVersion?: string;

--- a/src/types/testingbot-tunnel-launcher.d.ts
+++ b/src/types/testingbot-tunnel-launcher.d.ts
@@ -1,0 +1,28 @@
+declare module 'testingbot-tunnel-launcher' {
+  interface TestingBotTunnelOptions {
+    apiKey?: string;
+    apiSecret?: string;
+    tunnelIdentifier?: string;
+    logfile?: string;
+    verbose?: boolean;
+    'se-port'?: number | string;
+    [key: string]: string | number | boolean | undefined;
+  }
+
+  interface TestingBotTunnel {
+    close(callback?: () => void): void;
+    pid?: number;
+  }
+
+  interface TestingBotTunnelLauncher {
+    /** Callback form — downloads (if needed) and starts the tunnel. */
+    (options: TestingBotTunnelOptions, callback: (err: Error | null, tunnel: TestingBotTunnel) => void): void;
+    /** Promise form — resolves with the running tunnel handle. */
+    downloadAndRunAsync(options: TestingBotTunnelOptions): Promise<TestingBotTunnel>;
+    /** Stops any tunnel started by this process. */
+    killAsync(): Promise<void>;
+  }
+
+  const launcher: TestingBotTunnelLauncher;
+  export default launcher;
+}

--- a/tests/providers/registry.test.ts
+++ b/tests/providers/registry.test.ts
@@ -4,6 +4,7 @@ import { LocalBrowserProvider } from '../../src/providers/local-browser.provider
 import { LocalAppiumProvider } from '../../src/providers/local-appium.provider';
 import { BrowserStackProvider } from '../../src/providers/cloud/browserstack.provider';
 import { TestMuProvider } from '../../src/providers/cloud/testmu.provider';
+import { TestingBotProvider } from '../../src/providers/cloud/testingbot.provider';
 
 describe('getProvider', () => {
   it('returns LocalBrowserProvider for local browser', () => {
@@ -40,6 +41,18 @@ describe('getProvider', () => {
 
   it('returns TestMuProvider for testmu ios', () => {
     expect(getProvider('testmu', 'ios')).toBeInstanceOf(TestMuProvider);
+  });
+
+  it('returns TestingBotProvider for testingbot browser', () => {
+    expect(getProvider('testingbot', 'browser')).toBeInstanceOf(TestingBotProvider);
+  });
+
+  it('returns TestingBotProvider for testingbot android', () => {
+    expect(getProvider('testingbot', 'android')).toBeInstanceOf(TestingBotProvider);
+  });
+
+  it('returns TestingBotProvider for testingbot ios', () => {
+    expect(getProvider('testingbot', 'ios')).toBeInstanceOf(TestingBotProvider);
   });
 
   it('defaults to local when provider is undefined', () => {

--- a/tests/providers/testingbot.provider.test.ts
+++ b/tests/providers/testingbot.provider.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestingBotProvider } from '../../src/providers/cloud/testingbot.provider';
+import testingbotTunnel from 'testingbot-tunnel-launcher';
+
+vi.mock('testingbot-tunnel-launcher', () => ({
+  default: {
+    downloadAndRunAsync: vi.fn().mockResolvedValue({ close: (cb: () => void) => cb() }),
+    killAsync: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('TestingBotProvider', () => {
+  let provider: TestingBotProvider;
+
+  beforeEach(() => {
+    provider = new TestingBotProvider();
+    vi.stubEnv('TESTINGBOT_KEY', 'tb-key');
+    vi.stubEnv('TESTINGBOT_SECRET', 'tb-secret');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe('getConnectionConfig', () => {
+    it('returns hub.testingbot.com for browser platform', () => {
+      const config = provider.getConnectionConfig({ platform: 'browser' });
+      expect(config.hostname).toBe('hub.testingbot.com');
+      expect(config.protocol).toBe('https');
+      expect(config.port).toBe(443);
+      expect(config.path).toBe('/wd/hub');
+    });
+
+    it('uses the same hub for mobile platforms', () => {
+      expect(provider.getConnectionConfig({ platform: 'android' }).hostname).toBe('hub.testingbot.com');
+      expect(provider.getConnectionConfig({ platform: 'ios' }).hostname).toBe('hub.testingbot.com');
+    });
+
+    it('maps TESTINGBOT_KEY/SECRET to user/key', () => {
+      const config = provider.getConnectionConfig({});
+      expect(config.user).toBe('tb-key');
+      expect(config.key).toBe('tb-secret');
+    });
+  });
+
+  describe('buildCapabilities — browser platform', () => {
+    it('sets browserName and tb:options for browser platform', () => {
+      const caps = provider.buildCapabilities({ platform: 'browser', browser: 'chrome' });
+      expect(caps.browserName).toBe('chrome');
+      expect(caps['tb:options']).toBeDefined();
+    });
+
+    it('defaults browserVersion to latest', () => {
+      const caps = provider.buildCapabilities({ platform: 'browser', browser: 'firefox' });
+      expect(caps.browserVersion).toBe('latest');
+    });
+
+    it('defaults platformName to Windows 11', () => {
+      const caps = provider.buildCapabilities({ platform: 'browser', browser: 'chrome' });
+      expect(caps.platformName).toBe('Windows 11');
+    });
+
+    it('combines os and osVersion into platformName', () => {
+      const caps = provider.buildCapabilities({ platform: 'browser', browser: 'chrome', os: 'macOS', osVersion: 'Sonoma' });
+      expect(caps.platformName).toBe('macOS Sonoma');
+    });
+
+    it('passes reporting labels to tb:options', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'browser',
+        browser: 'firefox',
+        reporting: { project: 'MyProject', build: 'build-1', session: 'login test' },
+      });
+      const tb = caps['tb:options'] as Record<string, unknown>;
+      expect(tb.build).toBe('build-1');
+      expect(tb.name).toBe('login test');
+    });
+
+    it('uses project as name when session is not provided', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'browser',
+        browser: 'chrome',
+        reporting: { project: 'MyProject' },
+      });
+      const tb = caps['tb:options'] as Record<string, unknown>;
+      expect(tb.name).toBe('MyProject');
+    });
+
+    it('sets tunnel and tunnelIdentifier in tb:options when tunnel is enabled', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'browser',
+        browser: 'chrome',
+        tunnel: true,
+        tunnelName: 'my-tunnel',
+      });
+      const tb = caps['tb:options'] as Record<string, unknown>;
+      expect(tb.tunnel).toBe(true);
+      expect(tb.tunnelIdentifier).toBe('my-tunnel');
+    });
+
+    it('merges user capabilities at top level', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'browser',
+        browser: 'chrome',
+        capabilities: { 'goog:chromeOptions': { args: ['--custom-flag'] } },
+      });
+      expect((caps['goog:chromeOptions'] as { args?: string[] })?.args).toContain('--custom-flag');
+    });
+  });
+
+  describe('buildCapabilities — mobile platform', () => {
+    it('sets platformName and appium:app for android native app', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'android',
+        deviceName: 'Pixel 7',
+        platformVersion: '13',
+        app: 'tb://abc123',
+      });
+      expect(caps.platformName).toBe('android');
+      expect(caps['appium:app']).toBe('tb://abc123');
+      expect(caps['tb:options']).toBeDefined();
+    });
+
+    it('defaults autoGrantPermissions and autoAcceptAlerts to true', () => {
+      const caps = provider.buildCapabilities({ platform: 'android', deviceName: 'Pixel 7', app: 'tb://abc' });
+      expect(caps['appium:autoGrantPermissions']).toBe(true);
+      expect(caps['appium:autoAcceptAlerts']).toBe(true);
+    });
+
+    it('clears autoAcceptAlerts when autoDismissAlerts is set', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'android',
+        deviceName: 'Pixel 7',
+        app: 'tb://abc',
+        autoDismissAlerts: true,
+      });
+      expect(caps['appium:autoDismissAlerts']).toBe(true);
+      expect(caps['appium:autoAcceptAlerts']).toBeUndefined();
+    });
+
+    it('sets browserName for mobile browser mode (no app)', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'android',
+        deviceName: 'Pixel 7',
+        platformVersion: '13',
+        browser: 'chrome',
+      });
+      expect(caps.browserName).toBe('chrome');
+      expect(caps['appium:app']).toBeUndefined();
+    });
+
+    it('defaults automationName for iOS and Android', () => {
+      expect(provider.buildCapabilities({ platform: 'ios', deviceName: 'iPhone 15', app: 'tb://x' })['appium:automationName']).toBe('XCUITest');
+      expect(provider.buildCapabilities({ platform: 'android', deviceName: 'Pixel 7', app: 'tb://x' })['appium:automationName']).toBe('UiAutomator2');
+    });
+  });
+
+  describe('getSessionType', () => {
+    it('maps platform to session type', () => {
+      expect(provider.getSessionType({ platform: 'browser' })).toBe('browser');
+      expect(provider.getSessionType({ platform: 'ios' })).toBe('ios');
+      expect(provider.getSessionType({ platform: 'android' })).toBe('android');
+    });
+  });
+
+  describe('shouldAutoDetach', () => {
+    it('always returns false', () => {
+      expect(provider.shouldAutoDetach({})).toBe(false);
+    });
+  });
+
+  describe('startTunnel', () => {
+    it('starts the tunnel via downloadAndRunAsync and returns the handle', async () => {
+      const handle = await provider.startTunnel({ tunnelName: 'my-tunnel' });
+      expect(vi.mocked(testingbotTunnel.downloadAndRunAsync)).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'tb-key', apiSecret: 'tb-secret', tunnelIdentifier: 'my-tunnel' }),
+      );
+      expect(handle).not.toBeNull();
+    });
+
+    it('returns null when a tunnel is already running', async () => {
+      vi.mocked(testingbotTunnel.downloadAndRunAsync).mockRejectedValueOnce(new Error('tunnel already running'));
+      const handle = await provider.startTunnel({ tunnelName: 'dup' });
+      expect(handle).toBeNull();
+    });
+
+    it('rethrows unexpected errors', async () => {
+      vi.mocked(testingbotTunnel.downloadAndRunAsync).mockRejectedValueOnce(new Error('boom'));
+      await expect(provider.startTunnel({})).rejects.toThrow('boom');
+    });
+  });
+
+  describe('onSessionClose', () => {
+    it('sends a form-encoded PUT to mark a browser test passed', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+
+      await provider.onSessionClose('session-123', 'browser', { status: 'passed' });
+
+      const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://api.testingbot.com/v1/tests/session-123');
+      expect(options.method).toBe('PUT');
+      expect((options.headers as Record<string, string>)['Content-Type']).toBe('application/x-www-form-urlencoded');
+      expect(new URLSearchParams(options.body as string).get('test[success]')).toBe('1');
+    });
+
+    it('uses the same REST path for mobile sessions (success=0 on failure)', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+
+      await provider.onSessionClose('session-456', 'android', { status: 'failed', reason: 'crash' });
+
+      const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://api.testingbot.com/v1/tests/session-456');
+      const params = new URLSearchParams(options.body as string);
+      expect(params.get('test[success]')).toBe('0');
+      expect(params.get('test[status_message]')).toBe('crash');
+    });
+
+    it('skips the API call when credentials are missing', async () => {
+      vi.stubEnv('TESTINGBOT_KEY', '');
+      vi.stubEnv('TESTINGBOT_SECRET', '');
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+
+      await provider.onSessionClose('session-123', 'browser', { status: 'passed' });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when the REST call fails', async () => {
+      vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network error'));
+      await expect(
+        provider.onSessionClose('session-789', 'browser', { status: 'passed' }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/tools/cloud-provider.tool.test.ts
+++ b/tests/tools/cloud-provider.tool.test.ts
@@ -383,3 +383,88 @@ describe('upload_app tool (Sauce Labs)', () => {
     expect(result.content[0].text).toContain('SAUCE_USERNAME');
   });
 });
+
+// ─── TestingBot tests ─────────────────────────────────────────────────────────
+
+describe('list_apps tool (TestingBot)', () => {
+  beforeEach(() => {
+    vi.stubEnv('TESTINGBOT_KEY', 'tb-key');
+    vi.stubEnv('TESTINGBOT_SECRET', 'tb-secret');
+    vi.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('calls the /v1/storage endpoint once with Basic auth', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ app_url: 'tb://abc123', filename: 'MyApp.apk', created_at: '2026-03-01T10:00:00.000Z' }] }),
+    } as Response);
+
+    await callList({ provider: 'testingbot' });
+
+    const calls = vi.mocked(fetch).mock.calls;
+    expect(calls).toHaveLength(1);
+    const [url, options] = calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.testingbot.com/v1/storage');
+    expect((options?.headers as Record<string, string>)?.Authorization).toMatch(/^Basic /);
+  });
+
+  it('returns formatted app list with tb:// format', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ app_url: 'tb://abc123', filename: 'MyApp.apk', created_at: '2026-03-01T10:00:00.000Z' }] }),
+    } as Response);
+
+    const result = await callList({ provider: 'testingbot' });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('MyApp.apk');
+    expect(result.content[0].text).toContain('tb://abc123');
+  });
+
+  it('returns isError true when credentials are missing', async () => {
+    vi.unstubAllEnvs();
+    const result = await callList({ provider: 'testingbot' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('TESTINGBOT_KEY');
+  });
+});
+
+describe('upload_app tool (TestingBot)', () => {
+  beforeEach(() => {
+    vi.stubEnv('TESTINGBOT_KEY', 'tb-key');
+    vi.stubEnv('TESTINGBOT_SECRET', 'tb-secret');
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from('mock-file-content'));
+    vi.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('calls /v1/storage and returns a tb:// url', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ app_url: 'tb://newapp456' }),
+    } as Response);
+
+    const result = await callUpload({ provider: 'testingbot', path: '/local/myapp.apk' });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('tb://newapp456');
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.testingbot.com/v1/storage');
+  });
+
+  it('returns isError true when credentials are missing', async () => {
+    vi.unstubAllEnvs();
+    const result = await callUpload({ provider: 'testingbot', path: '/some/app.apk' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('TESTINGBOT_KEY');
+  });
+});


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Adds **TestingBot** as a cloud provider, at feature parity with the existing BrowserStack, Sauce Labs, and TestMu integrations. It slots into the established `SessionProvider` pattern (`src/providers/`) — one provider class plus the usual enum/dispatch widening — and follows the same shape as the TestMu integration in #116.

### New Provider (src/providers/cloud/testingbot.provider.ts)

`TestingBotProvider` implements the `SessionProvider` interface with three capability modes (browser, mobile browser/emulator, mobile native app), tunnel lifecycle via `testingbot-tunnel-launcher`, and session result reporting via the TestingBot REST API. Uses `TESTINGBOT_KEY` / `TESTINGBOT_SECRET` environment variables (mapped to WebDriver `user`/`key`); credentials never appear in tool call parameters. Hub: `hub.testingbot.com`, capability block `tb:options`.

### App Management (src/tools/cloud-provider.tool.ts)

- `list_apps` for TestingBot fetches `GET /v1/storage` (single call — no per-platform split needed) and returns `tb://` refs.
- `upload_app` uploads to `POST /v1/storage` (multipart field `file`), returns the `tb://` app URL for use in `start_session`.

### Result Marking

`PUT https://api.testingbot.com/v1/tests/:id` with form-encoded `test[success]=1|0`. A single code path covers both web and mobile sessions — the `:id` route accepts the WebDriver session UUID, so there's no web-REST / mobile-`execute` split.

### Tunnel Binary Resource (src/resources/testingbot-local.resource.ts)

`wdio://testingbot/local-binary` resource with the TestingBot Tunnel download URL and setup commands, matching the BrowserStack/Sauce Labs/TestMu pattern. Note: the TestingBot Tunnel is a single cross-platform Java JAR (requires Java 11+) rather than per-platform native binaries.

Also adds `tb:options` detection to the code generator (`wdio://session/current/code`), a type shim for the untyped `testingbot-tunnel-launcher` package, and README/CLAUDE.md documentation.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have squashed commits that belong together
- [x] I have tested with Claude (or another MCP-compatible client)
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added the necessary documentation for new/changed tools (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

**Testing:** `npm test` passes (411 tests across 30 files), including a new `testingbot.provider.test.ts` suite plus registry and cloud-tool cases. `npm run lint` is clean (0 errors) and `npm run bundle` builds. A live end-to-end browser session against a real TestingBot account was run and verified (session and pass/fail result confirmed on the TestingBot dashboard).

**Design notes:**
- Credentials use TestingBot's native `TESTINGBOT_KEY` / `TESTINGBOT_SECRET` naming (matches TestingBot docs and the `@wdio/testingbot-service` convention) rather than the `*_USERNAME` / `*_ACCESS_KEY` shape of the other providers.
- Browser sessions default `platformName` to `Windows 11` when `os` is omitted (TestingBot's most broadly available platform); overridable via `os` / `osVersion`.
- No deprecated `testingbotLocal` alias was added — this is a new provider, so it uses only the unified `tunnel` parameter.

### Reviewers: @webdriverio/project-committers


