### PR TITLE
feat:  bidi install/uninstall extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,9 +704,7 @@ Both tools require a `provider` parameter (`'browserstack'`, `'saucelabs'`, `'te
 | `launch_chrome`  | Launch a new Chrome instance with remote debugging enabled (for use with `start_session({ attach: true })`)                                                            |
 | `close_session`  | Close or detach from the current session (supports `detach: true` to disconnect without terminating)                                                                   |
 | `emulate_device` | Emulate a mobile/tablet device preset (viewport, DPR, UA, touch); requires BiDi session                                                                                |
-| `install_web_extension` | Install a web extension through WebDriver BiDi (`path`, `archivePath`, or `base64` extension data)                                                              |
-| `uninstall_web_extension` | Uninstall a web extension by id through WebDriver BiDi                                                                                                       |
-| `open_web_extension_page` | Open an installed extension page so normal page tools can drive its UI                                                                                       |
+| `open_web_extension` | Install a web extension through WebDriver BiDi and open one of its extension pages so normal page tools can drive its UI                                           |
 
 ### Navigation & Page Interaction (Web & Mobile)
 
@@ -893,18 +891,19 @@ emulate_device({device: 'reset'})        // restore desktop defaults
 ```javascript
 start_session({platform: 'browser', browser: 'chrome', capabilities: {webSocketUrl: true}})
 
-install_web_extension({
-    extensionData: {type: 'path', path: '/path/to/unpacked-extension'}
+open_web_extension({
+    extensionData: {type: 'path', path: '/path/to/unpacked-extension'},
+    path: 'options.html'
 })
 
-// Open and drive the extension UI with the normal page tools.
-open_web_extension_page({path: 'options.html'})
+// Drive the extension UI with the normal page tools.
 get_elements()
 click_element({selector: '#save'})
 
 // For remote/cloud sessions, send a packaged extension archive as base64.
-install_web_extension({
-    extensionData: {type: 'base64', value: '<base64-encoded-zip>'}
+open_web_extension({
+    extensionData: {type: 'base64', value: '<base64-encoded-zip>'},
+    path: 'options.html'
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -636,6 +636,9 @@ Both tools require a `provider` parameter (`'browserstack'`, `'saucelabs'`, `'te
 | `launch_chrome`  | Launch a new Chrome instance with remote debugging enabled (for use with `start_session({ attach: true })`)                                                            |
 | `close_session`  | Close or detach from the current session (supports `detach: true` to disconnect without terminating)                                                                   |
 | `emulate_device` | Emulate a mobile/tablet device preset (viewport, DPR, UA, touch); requires BiDi session                                                                                |
+| `install_web_extension` | Install a web extension through WebDriver BiDi (`path`, `archivePath`, or `base64` extension data)                                                              |
+| `uninstall_web_extension` | Uninstall a web extension by id through WebDriver BiDi                                                                                                       |
+| `open_web_extension_page` | Open an installed extension page so normal page tools can drive its UI                                                                                       |
 
 ### Navigation & Page Interaction (Web & Mobile)
 
@@ -815,6 +818,26 @@ emulate_device()                         // list available presets
 emulate_device({device: 'iPhone 15'})    // activate emulation
 emulate_device({device: 'Pixel 7'})      // switch device
 emulate_device({device: 'reset'})        // restore desktop defaults
+```
+
+**Web extensions (requires BiDi session):**
+
+```javascript
+start_session({platform: 'browser', browser: 'chrome', capabilities: {webSocketUrl: true}})
+
+install_web_extension({
+    extensionData: {type: 'path', path: '/path/to/unpacked-extension'}
+})
+
+// Open and drive the extension UI with the normal page tools.
+open_web_extension_page({path: 'options.html'})
+get_elements()
+click_element({selector: '#save'})
+
+// For remote/cloud sessions, send a packaged extension archive as base64.
+install_web_extension({
+    extensionData: {type: 'base64', value: '<base64-encoded-zip>'}
+})
 ```
 
 ### Mobile App Automation

--- a/src/recording/code-generator.ts
+++ b/src/recording/code-generator.ts
@@ -160,6 +160,21 @@ function generateStep(step: RecordedStep, history: SessionHistory): string {
       const scriptArgs = (p.args as unknown[])?.length ? `, ${indentJson(p.args)}` : '';
       return `await browser.execute(${scriptCode}${scriptArgs});`;
     }
+    case 'install_web_extension':
+      return `await browser.webExtensionInstall({ extensionData: ${indentJson(p.extensionData)} });`;
+    case 'uninstall_web_extension':
+      return `await browser.webExtensionUninstall({ extension: '${escapeStr(p.extension)}' });`;
+    case 'open_web_extension_page': {
+      if (p.url !== undefined) {
+        return `await browser.url('${escapeStr(p.url)}');`;
+      }
+      const scheme = p.scheme ?? 'chrome-extension';
+      const extensionPath = p.path === undefined ? '' : String(p.path).replace(/^\/+/, '');
+      if (p.extension === undefined) {
+        return '// open_web_extension_page omitted: replay requires extension or url';
+      }
+      return `await browser.url('${escapeStr(scheme)}://${escapeStr(p.extension)}/${escapeStr(extensionPath)}');`;
+    }
     default:
       return `// [unknown tool] ${step.tool}`;
   }

--- a/src/recording/code-generator.ts
+++ b/src/recording/code-generator.ts
@@ -19,7 +19,17 @@ function indentJson(value: unknown): string {
     .join('\n');
 }
 
-function generateStep(step: RecordedStep, history: SessionHistory): string {
+type GenerationContext = {
+  webExtensionInstallCount: number;
+  latestWebExtensionVar?: string;
+};
+
+function inferExtensionScheme(history: SessionHistory): 'chrome-extension' | 'moz-extension' {
+  const browserName = String(history.capabilities.browserName ?? '').toLowerCase();
+  return browserName.includes('firefox') ? 'moz-extension' : 'chrome-extension';
+}
+
+function generateStep(step: RecordedStep, history: SessionHistory, context: GenerationContext): string {
   if (step.tool === '__session_transition__') {
     const newId = (step.params.newSessionId as string) ?? 'unknown';
     return `// --- new session: ${newId} started at ${step.timestamp} ---`;
@@ -160,17 +170,27 @@ function generateStep(step: RecordedStep, history: SessionHistory): string {
       const scriptArgs = (p.args as unknown[])?.length ? `, ${indentJson(p.args)}` : '';
       return `await browser.execute(${scriptCode}${scriptArgs});`;
     }
-    case 'install_web_extension':
-      return `await browser.webExtensionInstall({ extensionData: ${indentJson(p.extensionData)} });`;
+    case 'install_web_extension': {
+      context.webExtensionInstallCount += 1;
+      const extensionVar = context.webExtensionInstallCount === 1
+        ? 'extension'
+        : `extension${context.webExtensionInstallCount}`;
+      context.latestWebExtensionVar = extensionVar;
+      const extensionBinding = extensionVar === 'extension' ? 'extension' : `extension: ${extensionVar}`;
+      return `const { ${extensionBinding} } = await browser.webExtensionInstall({ extensionData: ${indentJson(p.extensionData)} });`;
+    }
     case 'uninstall_web_extension':
       return `await browser.webExtensionUninstall({ extension: '${escapeStr(p.extension)}' });`;
     case 'open_web_extension_page': {
       if (p.url !== undefined) {
         return `await browser.url('${escapeStr(p.url)}');`;
       }
-      const scheme = p.scheme ?? 'chrome-extension';
+      const scheme = p.scheme ?? inferExtensionScheme(history);
       const extensionPath = p.path === undefined ? '' : String(p.path).replace(/^\/+/, '');
       if (p.extension === undefined) {
+        if (context.latestWebExtensionVar !== undefined) {
+          return `await browser.url(\`${escapeStr(scheme)}://\${${context.latestWebExtensionVar}}/${escapeStr(extensionPath)}\`);`;
+        }
         return '// open_web_extension_page omitted: replay requires extension or url';
       }
       return `await browser.url('${escapeStr(scheme)}://${escapeStr(p.extension)}/${escapeStr(extensionPath)}');`;
@@ -208,8 +228,9 @@ export function generateCode(history: SessionHistory): string {
       : isLambdaTest ? (ltOptions?.tunnel === true)
         : (tbOptions?.tunnel === true);
 
+  const context: GenerationContext = { webExtensionInstallCount: 0 };
   const steps = history.steps
-    .map(step => generateStep(step, history))
+    .map(step => generateStep(step, history, context))
     .join('\n')
     .split('\n')
     .map(line => `  ${line}`)

--- a/src/recording/code-generator.ts
+++ b/src/recording/code-generator.ts
@@ -19,17 +19,12 @@ function indentJson(value: unknown): string {
     .join('\n');
 }
 
-type GenerationContext = {
-  webExtensionInstallCount: number;
-  latestWebExtensionVar?: string;
-};
-
 function inferExtensionScheme(history: SessionHistory): 'chrome-extension' | 'moz-extension' {
   const browserName = String(history.capabilities.browserName ?? '').toLowerCase();
   return browserName.includes('firefox') ? 'moz-extension' : 'chrome-extension';
 }
 
-function generateStep(step: RecordedStep, history: SessionHistory, context: GenerationContext): string {
+function generateStep(step: RecordedStep, history: SessionHistory): string {
   if (step.tool === '__session_transition__') {
     const newId = (step.params.newSessionId as string) ?? 'unknown';
     return `// --- new session: ${newId} started at ${step.timestamp} ---`;
@@ -197,30 +192,13 @@ function generateStep(step: RecordedStep, history: SessionHistory, context: Gene
       const scriptArgs = (p.args as unknown[])?.length ? `, ${indentJson(p.args)}` : '';
       return `await browser.execute(${scriptCode}${scriptArgs});`;
     }
-    case 'install_web_extension': {
-      context.webExtensionInstallCount += 1;
-      const extensionVar = context.webExtensionInstallCount === 1
-        ? 'extension'
-        : `extension${context.webExtensionInstallCount}`;
-      context.latestWebExtensionVar = extensionVar;
-      const extensionBinding = extensionVar === 'extension' ? 'extension' : `extension: ${extensionVar}`;
-      return `const { ${extensionBinding} } = await browser.webExtensionInstall({ extensionData: ${indentJson(p.extensionData)} });`;
-    }
-    case 'uninstall_web_extension':
-      return `await browser.webExtensionUninstall({ extension: '${escapeStr(p.extension)}' });`;
-    case 'open_web_extension_page': {
-      if (p.url !== undefined) {
-        return `await browser.url('${escapeStr(p.url)}');`;
-      }
+    case 'open_web_extension': {
       const scheme = p.scheme ?? inferExtensionScheme(history);
-      const extensionPath = p.path === undefined ? '' : String(p.path).replace(/^\/+/, '');
-      if (p.extension === undefined) {
-        if (context.latestWebExtensionVar !== undefined) {
-          return `await browser.url(\`${escapeStr(scheme)}://\${${context.latestWebExtensionVar}}/${escapeStr(extensionPath)}\`);`;
-        }
-        return '// open_web_extension_page omitted: replay requires extension or url';
-      }
-      return `await browser.url('${escapeStr(scheme)}://${escapeStr(p.extension)}/${escapeStr(extensionPath)}');`;
+      const extensionPath = String(p.path).replace(/^\/+/, '');
+      return [
+        `const { extension } = await browser.webExtensionInstall({ extensionData: ${indentJson(p.extensionData)} });`,
+        `await browser.url(\`${escapeStr(scheme)}://\${extension}/${escapeStr(extensionPath)}\`);`,
+      ].join('\n');
     }
     default:
       return `// [unknown tool] ${step.tool}`;
@@ -257,9 +235,8 @@ export function generateCode(history: SessionHistory): string {
       : isLambdaTest ? (ltOptions?.tunnel === true)
         : (tbOptions?.tunnel === true);
 
-  const context: GenerationContext = { webExtensionInstallCount: 0 };
   const steps = history.steps
-    .map(step => generateStep(step, history, context))
+    .map(step => generateStep(step, history))
     .join('\n')
     .split('\n')
     .map(line => `  ${line}`)

--- a/src/server.ts
+++ b/src/server.ts
@@ -79,14 +79,7 @@ import { getTabsTool, getTabsToolDefinition } from './tools/get-tabs.tool';
 import { getContextsTool, getContextsToolDefinition } from './tools/get-contexts.tool';
 import { appStateTool, appStateToolDefinition } from './tools/app-state.tool';
 import { getCookiesTool, getCookiesToolDefinition } from './tools/get-cookies.tool';
-import {
-  installWebExtensionTool,
-  installWebExtensionToolDefinition,
-  openWebExtensionPageTool,
-  openWebExtensionPageToolDefinition,
-  uninstallWebExtensionTool,
-  uninstallWebExtensionToolDefinition,
-} from './tools/web-extension.tool';
+import { openWebExtensionTool, openWebExtensionToolDefinition } from './tools/web-extension.tool';
 
 console.log = (...args) => console.error('[LOG]', ...args);
 console.info = (...args) => console.error('[INFO]', ...args);
@@ -165,9 +158,7 @@ function createServer(): McpServer {
 
   registerTool(executeScriptToolDefinition, instrument('execute_script', executeScriptTool));
   registerTool(getElementsToolDefinition, getElementsTool);
-  registerTool(installWebExtensionToolDefinition, withRecording('install_web_extension', installWebExtensionTool));
-  registerTool(uninstallWebExtensionToolDefinition, withRecording('uninstall_web_extension', uninstallWebExtensionTool));
-  registerTool(openWebExtensionPageToolDefinition, instrument('open_web_extension_page', openWebExtensionPageTool));
+  registerTool(openWebExtensionToolDefinition, instrument('open_web_extension', openWebExtensionTool));
 
   registerTool(listAppsToolDefinition, listAppsTool);
   registerTool(uploadAppToolDefinition, uploadAppTool);

--- a/src/server.ts
+++ b/src/server.ts
@@ -79,6 +79,14 @@ import { getTabsTool, getTabsToolDefinition } from './tools/get-tabs.tool';
 import { getContextsTool, getContextsToolDefinition } from './tools/get-contexts.tool';
 import { appStateTool, appStateToolDefinition } from './tools/app-state.tool';
 import { getCookiesTool, getCookiesToolDefinition } from './tools/get-cookies.tool';
+import {
+  installWebExtensionTool,
+  installWebExtensionToolDefinition,
+  openWebExtensionPageTool,
+  openWebExtensionPageToolDefinition,
+  uninstallWebExtensionTool,
+  uninstallWebExtensionToolDefinition,
+} from './tools/web-extension.tool';
 
 console.log = (...args) => console.error('[LOG]', ...args);
 console.info = (...args) => console.error('[INFO]', ...args);
@@ -157,6 +165,9 @@ function createServer(): McpServer {
 
   registerTool(executeScriptToolDefinition, instrument('execute_script', executeScriptTool));
   registerTool(getElementsToolDefinition, getElementsTool);
+  registerTool(installWebExtensionToolDefinition, withRecording('install_web_extension', installWebExtensionTool));
+  registerTool(uninstallWebExtensionToolDefinition, withRecording('uninstall_web_extension', uninstallWebExtensionTool));
+  registerTool(openWebExtensionPageToolDefinition, instrument('open_web_extension_page', openWebExtensionPageTool));
 
   registerTool(listAppsToolDefinition, listAppsTool);
   registerTool(uploadAppToolDefinition, uploadAppTool);

--- a/src/session/state.ts
+++ b/src/session/state.ts
@@ -4,6 +4,7 @@ export interface SessionMetadata {
   type: 'browser' | 'ios' | 'android';
   capabilities: Record<string, unknown>;
   isAttached: boolean;
+  webExtensions?: string[];
   provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot';
   region?: string;
   tunnelName?: string;

--- a/src/session/state.ts
+++ b/src/session/state.ts
@@ -5,8 +5,6 @@ export interface SessionMetadata {
   capabilities: Record<string, unknown>;
   isAttached: boolean;
   provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot' | 'digitalai';
-  webExtensions?: string[];
-  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot';
   region?: string;
   tunnelName?: string;
   tunnelHandle?: unknown;

--- a/src/tools/web-extension.tool.ts
+++ b/src/tools/web-extension.tool.ts
@@ -1,0 +1,255 @@
+import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { getBrowser, getState } from '../session/state';
+import type { ToolDefinition } from '../types/tool';
+
+type WebExtensionData =
+  | { type: 'path'; path: string }
+  | { type: 'archivePath'; path: string }
+  | { type: 'base64'; value: string };
+
+type WebExtensionInstallResult = { extension: string };
+
+type WebExtensionBrowser = WebdriverIO.Browser & {
+  webExtensionInstall?: (params: { extensionData: WebExtensionData }) => Promise<WebExtensionInstallResult>;
+  webExtensionUninstall?: (params: { extension: string }) => Promise<Record<string, never> | null>;
+};
+
+type BrowserSession = {
+  browser: WebExtensionBrowser;
+  sessionId: string;
+};
+
+type InstallWebExtensionArgs = {
+  extensionData: WebExtensionData;
+};
+
+type UninstallWebExtensionArgs = {
+  extension: string;
+};
+
+type OpenWebExtensionPageArgs = {
+  extension?: string;
+  path?: string;
+  url?: string;
+  scheme?: 'chrome-extension' | 'moz-extension';
+};
+
+const extensionDataSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('path'),
+    path: z.string().min(1).describe('Path to an unpacked extension directory on the remote end.'),
+  }),
+  z.object({
+    type: z.literal('archivePath'),
+    path: z.string().min(1).describe('Path to a packaged extension archive on the remote end.'),
+  }),
+  z.object({
+    type: z.literal('base64'),
+    value: z.string().min(1).describe('Base64-encoded packaged extension archive.'),
+  }),
+]);
+
+function getBrowserSession(): BrowserSession | CallToolResult {
+  const state = getState();
+  const sessionId = state.currentSession;
+  if (!sessionId) {
+    return {
+      isError: true,
+      content: [{ type: 'text', text: 'Error: No active browser session' }],
+    };
+  }
+
+  const browser = getBrowser() as WebExtensionBrowser;
+  const metadata = state.sessionMetadata.get(sessionId);
+
+  if (metadata?.type === 'ios' || metadata?.type === 'android') {
+    return {
+      isError: true,
+      content: [{ type: 'text', text: 'Error: web extension tools are only supported for browser sessions.' }],
+    };
+  }
+
+  if (!browser.isBidi) {
+    return {
+      isError: true,
+      content: [{
+        type: 'text',
+        text: 'Error: web extension tools require a BiDi-enabled browser session. Start a browser session with capabilities: { webSocketUrl: true }.',
+      }],
+    };
+  }
+
+  return { browser, sessionId };
+}
+
+function isToolResult(value: BrowserSession | CallToolResult): value is CallToolResult {
+  return 'content' in value;
+}
+
+function rememberExtension(sessionId: string, extension: string): void {
+  const state = getState();
+  const metadata = state.sessionMetadata.get(sessionId);
+  if (!metadata) return;
+
+  const extensions = metadata.webExtensions ?? [];
+  if (!extensions.includes(extension)) {
+    extensions.push(extension);
+  }
+  metadata.webExtensions = extensions;
+}
+
+function forgetExtension(sessionId: string, extension: string): void {
+  const state = getState();
+  const metadata = state.sessionMetadata.get(sessionId);
+  if (!metadata?.webExtensions) return;
+
+  metadata.webExtensions = metadata.webExtensions.filter((id) => id !== extension);
+  if (metadata.webExtensions.length === 0) {
+    delete metadata.webExtensions;
+  }
+}
+
+function getLatestExtension(sessionId: string): string | undefined {
+  const extensions = getState().sessionMetadata.get(sessionId)?.webExtensions;
+  return extensions?.[extensions.length - 1];
+}
+
+function inferExtensionScheme(browser: WebExtensionBrowser): 'chrome-extension' | 'moz-extension' {
+  const browserName = String(browser.capabilities?.browserName ?? '').toLowerCase();
+  return browser.isFirefox || browserName.includes('firefox') ? 'moz-extension' : 'chrome-extension';
+}
+
+function normalizeExtensionPath(path?: string): string {
+  if (!path) return '';
+  return path.replace(/^\/+/, '');
+}
+
+function resolveExtensionUrl(session: BrowserSession, args: OpenWebExtensionPageArgs): string | undefined {
+  if (args.url) return args.url;
+
+  const extensionId = args.extension ?? getLatestExtension(session.sessionId);
+  if (!extensionId) return undefined;
+
+  const scheme = args.scheme ?? inferExtensionScheme(session.browser);
+  return `${scheme}://${extensionId}/${normalizeExtensionPath(args.path)}`;
+}
+
+export const installWebExtensionToolDefinition: ToolDefinition = {
+  name: 'install_web_extension',
+  description: 'Installs a web extension through the W3C WebDriver BiDi webExtension.install command. Requires a BiDi-enabled browser session. Use base64 for cloud/remote sessions where the browser driver cannot read the MCP server filesystem.',
+  annotations: { title: 'Install Web Extension', destructiveHint: false },
+  inputSchema: {
+    extensionData: extensionDataSchema.describe('W3C BiDi webExtension.ExtensionData: unpacked directory path, archive path, or base64 archive.'),
+  },
+};
+
+export const uninstallWebExtensionToolDefinition: ToolDefinition = {
+  name: 'uninstall_web_extension',
+  description: 'Uninstalls a previously installed web extension through the W3C WebDriver BiDi webExtension.uninstall command.',
+  annotations: { title: 'Uninstall Web Extension', destructiveHint: true },
+  inputSchema: {
+    extension: z.string().min(1).describe('Extension id returned by install_web_extension.'),
+  },
+};
+
+export const openWebExtensionPageToolDefinition: ToolDefinition = {
+  name: 'open_web_extension_page',
+  description: 'Opens an installed extension page so existing MCP tools can inspect and drive its UI. Provide url directly, or provide extension/path to build a chrome-extension:// or moz-extension:// URL.',
+  annotations: { title: 'Open Web Extension Page', destructiveHint: false },
+  inputSchema: {
+    extension: z.string().min(1).optional().describe('Extension id. Defaults to the most recently installed extension in the active session.'),
+    path: z.string().optional().describe('Path inside the extension package, such as options.html or popup.html. Leading slashes are ignored.'),
+    url: z.string().min(1).optional().describe('Full extension URL to open directly. If set, extension/path/scheme are ignored.'),
+    scheme: z.enum(['chrome-extension', 'moz-extension']).optional().describe('Extension URL scheme. Defaults to moz-extension for Firefox and chrome-extension otherwise.'),
+  },
+};
+
+export const installWebExtensionTool: ToolCallback = async ({ extensionData }: InstallWebExtensionArgs): Promise<CallToolResult> => {
+  try {
+    const session = getBrowserSession();
+    if (isToolResult(session)) return session;
+
+    if (typeof session.browser.webExtensionInstall !== 'function') {
+      return {
+        isError: true,
+        content: [{
+          type: 'text',
+          text: 'Error: the active WebdriverIO browser does not expose webExtensionInstall. Upgrade WebdriverIO or use a browser driver with WebDriver BiDi webExtension support.',
+        }],
+      };
+    }
+
+    const result = await session.browser.webExtensionInstall({ extensionData });
+    if (!result?.extension || typeof result.extension !== 'string') {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Error: webExtension.install returned an unexpected result: ${JSON.stringify(result)}` }],
+      };
+    }
+
+    rememberExtension(session.sessionId, result.extension);
+    return {
+      content: [{ type: 'text', text: `Installed web extension: ${result.extension}` }],
+    };
+  } catch (e) {
+    return {
+      isError: true,
+      content: [{ type: 'text', text: `Error installing web extension: ${e}` }],
+    };
+  }
+};
+
+export const uninstallWebExtensionTool: ToolCallback = async ({ extension }: UninstallWebExtensionArgs): Promise<CallToolResult> => {
+  try {
+    const session = getBrowserSession();
+    if (isToolResult(session)) return session;
+
+    if (typeof session.browser.webExtensionUninstall !== 'function') {
+      return {
+        isError: true,
+        content: [{
+          type: 'text',
+          text: 'Error: the active WebdriverIO browser does not expose webExtensionUninstall. Upgrade WebdriverIO or use a browser driver with WebDriver BiDi webExtension support.',
+        }],
+      };
+    }
+
+    await session.browser.webExtensionUninstall({ extension });
+    forgetExtension(session.sessionId, extension);
+    return {
+      content: [{ type: 'text', text: `Uninstalled web extension: ${extension}` }],
+    };
+  } catch (e) {
+    return {
+      isError: true,
+      content: [{ type: 'text', text: `Error uninstalling web extension: ${e}` }],
+    };
+  }
+};
+
+export const openWebExtensionPageTool: ToolCallback = async (args: OpenWebExtensionPageArgs): Promise<CallToolResult> => {
+  try {
+    const session = getBrowserSession();
+    if (isToolResult(session)) return session;
+
+    const targetUrl = resolveExtensionUrl(session, args);
+    if (!targetUrl) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: 'Error: provide url, extension, or install a web extension first.' }],
+      };
+    }
+
+    await session.browser.url(targetUrl);
+    return {
+      content: [{ type: 'text', text: `Opened web extension page: ${targetUrl}` }],
+    };
+  } catch (e) {
+    return {
+      isError: true,
+      content: [{ type: 'text', text: `Error opening web extension page: ${e}` }],
+    };
+  }
+};

--- a/src/tools/web-extension.tool.ts
+++ b/src/tools/web-extension.tool.ts
@@ -234,6 +234,10 @@ export const openWebExtensionPageTool: ToolCallback = async (args: OpenWebExtens
     const session = getBrowserSession();
     if (isToolResult(session)) return session;
 
+    if (args.url === undefined && args.scheme === undefined) {
+      args.scheme = inferExtensionScheme(session.browser);
+    }
+
     const targetUrl = resolveExtensionUrl(session, args);
     if (!targetUrl) {
       return {

--- a/src/tools/web-extension.tool.ts
+++ b/src/tools/web-extension.tool.ts
@@ -13,26 +13,15 @@ type WebExtensionInstallResult = { extension: string };
 
 type WebExtensionBrowser = WebdriverIO.Browser & {
   webExtensionInstall?: (params: { extensionData: WebExtensionData }) => Promise<WebExtensionInstallResult>;
-  webExtensionUninstall?: (params: { extension: string }) => Promise<Record<string, never> | null>;
 };
 
 type BrowserSession = {
   browser: WebExtensionBrowser;
-  sessionId: string;
 };
 
-type InstallWebExtensionArgs = {
+type OpenWebExtensionArgs = {
   extensionData: WebExtensionData;
-};
-
-type UninstallWebExtensionArgs = {
-  extension: string;
-};
-
-type OpenWebExtensionPageArgs = {
-  extension?: string;
-  path?: string;
-  url?: string;
+  path: string;
   scheme?: 'chrome-extension' | 'moz-extension';
 };
 
@@ -81,39 +70,11 @@ function getBrowserSession(): BrowserSession | CallToolResult {
     };
   }
 
-  return { browser, sessionId };
+  return { browser };
 }
 
 function isToolResult(value: BrowserSession | CallToolResult): value is CallToolResult {
   return 'content' in value;
-}
-
-function rememberExtension(sessionId: string, extension: string): void {
-  const state = getState();
-  const metadata = state.sessionMetadata.get(sessionId);
-  if (!metadata) return;
-
-  const extensions = metadata.webExtensions ?? [];
-  if (!extensions.includes(extension)) {
-    extensions.push(extension);
-  }
-  metadata.webExtensions = extensions;
-}
-
-function forgetExtension(sessionId: string, extension: string): void {
-  const state = getState();
-  const metadata = state.sessionMetadata.get(sessionId);
-  if (!metadata?.webExtensions) return;
-
-  metadata.webExtensions = metadata.webExtensions.filter((id) => id !== extension);
-  if (metadata.webExtensions.length === 0) {
-    delete metadata.webExtensions;
-  }
-}
-
-function getLatestExtension(sessionId: string): string | undefined {
-  const extensions = getState().sessionMetadata.get(sessionId)?.webExtensions;
-  return extensions?.[extensions.length - 1];
 }
 
 function inferExtensionScheme(browser: WebExtensionBrowser): 'chrome-extension' | 'moz-extension' {
@@ -121,52 +82,21 @@ function inferExtensionScheme(browser: WebExtensionBrowser): 'chrome-extension' 
   return browser.isFirefox || browserName.includes('firefox') ? 'moz-extension' : 'chrome-extension';
 }
 
-function normalizeExtensionPath(path?: string): string {
-  if (!path) return '';
+function normalizeExtensionPath(path: string): string {
   return path.replace(/^\/+/, '');
 }
 
-function resolveExtensionUrl(session: BrowserSession, args: OpenWebExtensionPageArgs): string | undefined {
-  if (args.url) return args.url;
-
-  const extensionId = args.extension ?? getLatestExtension(session.sessionId);
-  if (!extensionId) return undefined;
-
-  const scheme = args.scheme ?? inferExtensionScheme(session.browser);
-  return `${scheme}://${extensionId}/${normalizeExtensionPath(args.path)}`;
-}
-
-export const installWebExtensionToolDefinition: ToolDefinition = {
-  name: 'install_web_extension',
-  description: 'Installs a web extension through the W3C WebDriver BiDi webExtension.install command. Requires a BiDi-enabled browser session. Use base64 for cloud/remote sessions where the browser driver cannot read the MCP server filesystem.',
-  annotations: { title: 'Install Web Extension', destructiveHint: false },
+export const openWebExtensionToolDefinition: ToolDefinition = {
+  name: 'open_web_extension',
+  description: 'Installs a web extension through WebDriver BiDi and opens one of its extension pages so existing MCP tools can inspect and drive its UI. Requires a BiDi-enabled browser session. Use base64 for cloud/remote sessions where the browser driver cannot read the MCP server filesystem.',
+  annotations: { title: 'Open Web Extension', destructiveHint: false },
   inputSchema: {
     extensionData: extensionDataSchema.describe('W3C BiDi webExtension.ExtensionData: unpacked directory path, archive path, or base64 archive.'),
+    path: z.string().min(1).describe('Path inside the extension package, such as options.html or popup.html. Leading slashes are ignored.'),
   },
 };
 
-export const uninstallWebExtensionToolDefinition: ToolDefinition = {
-  name: 'uninstall_web_extension',
-  description: 'Uninstalls a previously installed web extension through the W3C WebDriver BiDi webExtension.uninstall command.',
-  annotations: { title: 'Uninstall Web Extension', destructiveHint: true },
-  inputSchema: {
-    extension: z.string().min(1).describe('Extension id returned by install_web_extension.'),
-  },
-};
-
-export const openWebExtensionPageToolDefinition: ToolDefinition = {
-  name: 'open_web_extension_page',
-  description: 'Opens an installed extension page so existing MCP tools can inspect and drive its UI. Provide url directly, or provide extension/path to build a chrome-extension:// or moz-extension:// URL.',
-  annotations: { title: 'Open Web Extension Page', destructiveHint: false },
-  inputSchema: {
-    extension: z.string().min(1).optional().describe('Extension id. Defaults to the most recently installed extension in the active session.'),
-    path: z.string().optional().describe('Path inside the extension package, such as options.html or popup.html. Leading slashes are ignored.'),
-    url: z.string().min(1).optional().describe('Full extension URL to open directly. If set, extension/path/scheme are ignored.'),
-    scheme: z.enum(['chrome-extension', 'moz-extension']).optional().describe('Extension URL scheme. Defaults to moz-extension for Firefox and chrome-extension otherwise.'),
-  },
-};
-
-export const installWebExtensionTool: ToolCallback = async ({ extensionData }: InstallWebExtensionArgs): Promise<CallToolResult> => {
+export const openWebExtensionTool: ToolCallback = async (args: OpenWebExtensionArgs): Promise<CallToolResult> => {
   try {
     const session = getBrowserSession();
     if (isToolResult(session)) return session;
@@ -181,7 +111,7 @@ export const installWebExtensionTool: ToolCallback = async ({ extensionData }: I
       };
     }
 
-    const result = await session.browser.webExtensionInstall({ extensionData });
+    const result = await session.browser.webExtensionInstall({ extensionData: args.extensionData });
     if (!result?.extension || typeof result.extension !== 'string') {
       return {
         isError: true,
@@ -189,71 +119,19 @@ export const installWebExtensionTool: ToolCallback = async ({ extensionData }: I
       };
     }
 
-    rememberExtension(session.sessionId, result.extension);
-    return {
-      content: [{ type: 'text', text: `Installed web extension: ${result.extension}` }],
-    };
-  } catch (e) {
-    return {
-      isError: true,
-      content: [{ type: 'text', text: `Error installing web extension: ${e}` }],
-    };
-  }
-};
+    const scheme = args.scheme ?? inferExtensionScheme(session.browser);
+    args.scheme = scheme;
 
-export const uninstallWebExtensionTool: ToolCallback = async ({ extension }: UninstallWebExtensionArgs): Promise<CallToolResult> => {
-  try {
-    const session = getBrowserSession();
-    if (isToolResult(session)) return session;
-
-    if (typeof session.browser.webExtensionUninstall !== 'function') {
-      return {
-        isError: true,
-        content: [{
-          type: 'text',
-          text: 'Error: the active WebdriverIO browser does not expose webExtensionUninstall. Upgrade WebdriverIO or use a browser driver with WebDriver BiDi webExtension support.',
-        }],
-      };
-    }
-
-    await session.browser.webExtensionUninstall({ extension });
-    forgetExtension(session.sessionId, extension);
-    return {
-      content: [{ type: 'text', text: `Uninstalled web extension: ${extension}` }],
-    };
-  } catch (e) {
-    return {
-      isError: true,
-      content: [{ type: 'text', text: `Error uninstalling web extension: ${e}` }],
-    };
-  }
-};
-
-export const openWebExtensionPageTool: ToolCallback = async (args: OpenWebExtensionPageArgs): Promise<CallToolResult> => {
-  try {
-    const session = getBrowserSession();
-    if (isToolResult(session)) return session;
-
-    if (args.url === undefined && args.scheme === undefined) {
-      args.scheme = inferExtensionScheme(session.browser);
-    }
-
-    const targetUrl = resolveExtensionUrl(session, args);
-    if (!targetUrl) {
-      return {
-        isError: true,
-        content: [{ type: 'text', text: 'Error: provide url, extension, or install a web extension first.' }],
-      };
-    }
-
+    const targetUrl = `${scheme}://${result.extension}/${normalizeExtensionPath(args.path)}`;
     await session.browser.url(targetUrl);
+
     return {
       content: [{ type: 'text', text: `Opened web extension page: ${targetUrl}` }],
     };
   } catch (e) {
     return {
       isError: true,
-      content: [{ type: 'text', text: `Error opening web extension page: ${e}` }],
+      content: [{ type: 'text', text: `Error opening web extension: ${e}` }],
     };
   }
 };

--- a/src/trace/tool-mapping.ts
+++ b/src/trace/tool-mapping.ts
@@ -13,6 +13,7 @@ const TOOL_MAP: Record<string, TraceAction> = {
   drag_and_drop: { class: 'Element', method: 'dragTo' },
   execute_script: { class: 'Page', method: 'evaluate' },
   launch_chrome: { class: 'Browser', method: 'launch' },
+  open_web_extension_page: { class: 'Page', method: 'navigate' },
 };
 
 export function mapToolToTraceAction(toolName: string): TraceAction | null {

--- a/src/trace/tool-mapping.ts
+++ b/src/trace/tool-mapping.ts
@@ -13,7 +13,7 @@ const TOOL_MAP: Record<string, TraceAction> = {
   drag_and_drop: { class: 'Element', method: 'dragTo' },
   execute_script: { class: 'Page', method: 'evaluate' },
   launch_chrome: { class: 'Browser', method: 'launch' },
-  open_web_extension_page: { class: 'Page', method: 'navigate' },
+  open_web_extension: { class: 'Page', method: 'navigate' },
 };
 
 export function mapToolToTraceAction(toolName: string): TraceAction | null {

--- a/tests/recording/code-generator.test.ts
+++ b/tests/recording/code-generator.test.ts
@@ -221,6 +221,40 @@ describe('generateCode - tool mappings', () => {
     }]));
     expect(code).toContain("await browser.$('#from').dragAndDrop({ x: 50, y: 75 });");
   });
+
+  it('install_web_extension → browser.webExtensionInstall()', () => {
+    const code = generateCode(makeHistory([{
+      tool: 'install_web_extension',
+      params: { extensionData: { type: 'path', path: '/tmp/ext' } },
+    }]));
+    expect(code).toContain('await browser.webExtensionInstall({ extensionData:');
+    expect(code).toContain('"type": "path"');
+    expect(code).toContain('/tmp/ext');
+  });
+
+  it('uninstall_web_extension → browser.webExtensionUninstall()', () => {
+    const code = generateCode(makeHistory([{
+      tool: 'uninstall_web_extension',
+      params: { extension: 'ext-123' },
+    }]));
+    expect(code).toContain("await browser.webExtensionUninstall({ extension: 'ext-123' });");
+  });
+
+  it('open_web_extension_page with url → browser.url()', () => {
+    const code = generateCode(makeHistory([{
+      tool: 'open_web_extension_page',
+      params: { url: 'chrome-extension://ext-123/options.html' },
+    }]));
+    expect(code).toContain("await browser.url('chrome-extension://ext-123/options.html');");
+  });
+
+  it('open_web_extension_page with extension/path → browser.url()', () => {
+    const code = generateCode(makeHistory([{
+      tool: 'open_web_extension_page',
+      params: { extension: 'ext-123', path: '/options.html', scheme: 'chrome-extension' },
+    }]));
+    expect(code).toContain("await browser.url('chrome-extension://ext-123/options.html');");
+  });
 });
 
 describe('generateCode - BrowserStack Local tunnel', () => {

--- a/tests/recording/code-generator.test.ts
+++ b/tests/recording/code-generator.test.ts
@@ -258,94 +258,37 @@ describe('generateCode - tool mappings', () => {
     expect(code).toContain("await browser.$('#from').dragAndDrop({ x: 50, y: 75 });");
   });
 
-  it('install_web_extension → browser.webExtensionInstall()', () => {
+  it('open_web_extension → browser.webExtensionInstall() and browser.url()', () => {
     const code = generateCode(makeHistory([{
-      tool: 'install_web_extension',
-      params: { extensionData: { type: 'path', path: '/tmp/ext' } },
+      tool: 'open_web_extension',
+      params: { extensionData: { type: 'path', path: '/tmp/ext' }, path: 'options.html', scheme: 'chrome-extension' },
     }]));
+
     expect(code).toContain('const { extension } = await browser.webExtensionInstall({ extensionData:');
     expect(code).toContain('"type": "path"');
     expect(code).toContain('/tmp/ext');
-  });
-
-  it('uninstall_web_extension → browser.webExtensionUninstall()', () => {
-    const code = generateCode(makeHistory([{
-      tool: 'uninstall_web_extension',
-      params: { extension: 'ext-123' },
-    }]));
-    expect(code).toContain("await browser.webExtensionUninstall({ extension: 'ext-123' });");
-  });
-
-  it('open_web_extension_page with url → browser.url()', () => {
-    const code = generateCode(makeHistory([{
-      tool: 'open_web_extension_page',
-      params: { url: 'chrome-extension://ext-123/options.html' },
-    }]));
-    expect(code).toContain("await browser.url('chrome-extension://ext-123/options.html');");
-  });
-
-  it('open_web_extension_page with extension/path → browser.url()', () => {
-    const code = generateCode(makeHistory([{
-      tool: 'open_web_extension_page',
-      params: { extension: 'ext-123', path: '/options.html', scheme: 'chrome-extension' },
-    }]));
-    expect(code).toContain("await browser.url('chrome-extension://ext-123/options.html');");
-  });
-
-  it('open_web_extension_page uses latest installed extension variable when extension is omitted', () => {
-    const code = generateCode(makeHistory([
-      {
-        tool: 'install_web_extension',
-        params: { extensionData: { type: 'path', path: '/tmp/ext' } },
-      },
-      {
-        tool: 'open_web_extension_page',
-        params: { path: '/options.html', scheme: 'chrome-extension' },
-      },
-    ]));
-
-    expect(code).toContain('const { extension } = await browser.webExtensionInstall({ extensionData:');
     expect(code).toContain('await browser.url(`chrome-extension://${extension}/options.html`);');
-    expect(code).not.toContain('open_web_extension_page omitted');
   });
 
-  it('open_web_extension_page infers moz-extension for legacy Firefox recordings without scheme', () => {
-    const history = makeHistory([
-      {
-        tool: 'install_web_extension',
-        params: { extensionData: { type: 'path', path: '/tmp/firefox-ext' } },
-      },
-      {
-        tool: 'open_web_extension_page',
-        params: { path: 'popup.html' },
-      },
-    ]);
+  it('open_web_extension strips leading slashes in generated navigation URL', () => {
+    const code = generateCode(makeHistory([{
+      tool: 'open_web_extension',
+      params: { extensionData: { type: 'path', path: '/tmp/ext' }, path: '/options.html', scheme: 'chrome-extension' },
+    }]));
+
+    expect(code).toContain('await browser.url(`chrome-extension://${extension}/options.html`);');
+  });
+
+  it('open_web_extension infers moz-extension for recordings without scheme', () => {
+    const history = makeHistory([{
+      tool: 'open_web_extension',
+      params: { extensionData: { type: 'path', path: '/tmp/firefox-ext' }, path: 'popup.html' },
+    }]);
     history.capabilities = { browserName: 'firefox' };
 
     const code = generateCode(history);
 
     expect(code).toContain('await browser.url(`moz-extension://${extension}/popup.html`);');
-  });
-
-  it('open_web_extension_page uses the latest variable after multiple extension installs', () => {
-    const code = generateCode(makeHistory([
-      {
-        tool: 'install_web_extension',
-        params: { extensionData: { type: 'path', path: '/tmp/ext-1' } },
-      },
-      {
-        tool: 'install_web_extension',
-        params: { extensionData: { type: 'path', path: '/tmp/ext-2' } },
-      },
-      {
-        tool: 'open_web_extension_page',
-        params: { path: 'popup.html' },
-      },
-    ]));
-
-    expect(code).toContain('const { extension } = await browser.webExtensionInstall({ extensionData:');
-    expect(code).toContain('const { extension: extension2 } = await browser.webExtensionInstall({ extensionData:');
-    expect(code).toContain('await browser.url(`chrome-extension://${extension2}/popup.html`);');
   });
 });
 

--- a/tests/recording/code-generator.test.ts
+++ b/tests/recording/code-generator.test.ts
@@ -227,7 +227,7 @@ describe('generateCode - tool mappings', () => {
       tool: 'install_web_extension',
       params: { extensionData: { type: 'path', path: '/tmp/ext' } },
     }]));
-    expect(code).toContain('await browser.webExtensionInstall({ extensionData:');
+    expect(code).toContain('const { extension } = await browser.webExtensionInstall({ extensionData:');
     expect(code).toContain('"type": "path"');
     expect(code).toContain('/tmp/ext');
   });
@@ -254,6 +254,62 @@ describe('generateCode - tool mappings', () => {
       params: { extension: 'ext-123', path: '/options.html', scheme: 'chrome-extension' },
     }]));
     expect(code).toContain("await browser.url('chrome-extension://ext-123/options.html');");
+  });
+
+  it('open_web_extension_page uses latest installed extension variable when extension is omitted', () => {
+    const code = generateCode(makeHistory([
+      {
+        tool: 'install_web_extension',
+        params: { extensionData: { type: 'path', path: '/tmp/ext' } },
+      },
+      {
+        tool: 'open_web_extension_page',
+        params: { path: '/options.html', scheme: 'chrome-extension' },
+      },
+    ]));
+
+    expect(code).toContain('const { extension } = await browser.webExtensionInstall({ extensionData:');
+    expect(code).toContain('await browser.url(`chrome-extension://${extension}/options.html`);');
+    expect(code).not.toContain('open_web_extension_page omitted');
+  });
+
+  it('open_web_extension_page infers moz-extension for legacy Firefox recordings without scheme', () => {
+    const history = makeHistory([
+      {
+        tool: 'install_web_extension',
+        params: { extensionData: { type: 'path', path: '/tmp/firefox-ext' } },
+      },
+      {
+        tool: 'open_web_extension_page',
+        params: { path: 'popup.html' },
+      },
+    ]);
+    history.capabilities = { browserName: 'firefox' };
+
+    const code = generateCode(history);
+
+    expect(code).toContain('await browser.url(`moz-extension://${extension}/popup.html`);');
+  });
+
+  it('open_web_extension_page uses the latest variable after multiple extension installs', () => {
+    const code = generateCode(makeHistory([
+      {
+        tool: 'install_web_extension',
+        params: { extensionData: { type: 'path', path: '/tmp/ext-1' } },
+      },
+      {
+        tool: 'install_web_extension',
+        params: { extensionData: { type: 'path', path: '/tmp/ext-2' } },
+      },
+      {
+        tool: 'open_web_extension_page',
+        params: { path: 'popup.html' },
+      },
+    ]));
+
+    expect(code).toContain('const { extension } = await browser.webExtensionInstall({ extensionData:');
+    expect(code).toContain('const { extension: extension2 } = await browser.webExtensionInstall({ extensionData:');
+    expect(code).toContain('await browser.url(`chrome-extension://${extension2}/popup.html`);');
   });
 });
 

--- a/tests/tools/web-extension-tool.test.ts
+++ b/tests/tools/web-extension-tool.test.ts
@@ -2,14 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp';
 import { getState } from '../../src/session/state';
 import { getSessionHistory, withRecording } from '../../src/recording/step-recorder';
-import {
-  installWebExtensionTool,
-  openWebExtensionPageTool,
-  uninstallWebExtensionTool,
-} from '../../src/tools/web-extension.tool';
+import { openWebExtensionTool } from '../../src/tools/web-extension.tool';
 
 const mockInstall = vi.fn();
-const mockUninstall = vi.fn();
 const mockUrl = vi.fn();
 
 type ToolFn = (args: Record<string, unknown>) => Promise<{
@@ -18,9 +13,7 @@ type ToolFn = (args: Record<string, unknown>) => Promise<{
 }>;
 type AnyToolFn = (params: Record<string, unknown>, extra: unknown) => Promise<unknown>;
 
-const callInstall = installWebExtensionTool as unknown as ToolFn;
-const callUninstall = uninstallWebExtensionTool as unknown as ToolFn;
-const callOpen = openWebExtensionPageTool as unknown as ToolFn;
+const callOpen = openWebExtensionTool as unknown as ToolFn;
 const extra = {} as Parameters<ToolCallback>[1];
 
 function setupSession(options: {
@@ -28,18 +21,14 @@ function setupSession(options: {
   isBidi?: boolean;
   browserName?: string;
   isFirefox?: boolean;
-  webExtensions?: string[];
   omitInstall?: boolean;
-  omitUninstall?: boolean;
 } = {}) {
   const {
     type = 'browser',
     isBidi = true,
     browserName = 'chrome',
     isFirefox = false,
-    webExtensions,
     omitInstall = false,
-    omitUninstall = false,
   } = options;
 
   const browser: Record<string, unknown> = {
@@ -52,9 +41,6 @@ function setupSession(options: {
   if (!omitInstall) {
     browser.webExtensionInstall = mockInstall;
   }
-  if (!omitUninstall) {
-    browser.webExtensionUninstall = mockUninstall;
-  }
 
   const state = getState();
   state.currentSession = 'test-session';
@@ -63,7 +49,6 @@ function setupSession(options: {
     type,
     capabilities: { browserName },
     isAttached: false,
-    ...(webExtensions ? { webExtensions } : {}),
   });
   state.sessionHistory.set('test-session', {
     sessionId: 'test-session',
@@ -77,7 +62,6 @@ function setupSession(options: {
 beforeEach(() => {
   vi.clearAllMocks();
   mockInstall.mockResolvedValue({ extension: 'ext-123' });
-  mockUninstall.mockResolvedValue(null);
   mockUrl.mockResolvedValue(undefined);
 
   const state = getState();
@@ -87,142 +71,124 @@ beforeEach(() => {
   state.currentSession = null;
 });
 
-describe('install_web_extension', () => {
+describe('open_web_extension', () => {
   it.each([
     { type: 'path', path: '/tmp/unpacked-extension' },
     { type: 'archivePath', path: '/tmp/extension.zip' },
     { type: 'base64', value: 'UEsDBAo=' },
-  ])('passes %s extensionData to webExtension.install', async (extensionData) => {
+  ])('installs %s extensionData and opens the requested extension page', async (extensionData) => {
     setupSession();
-    const result = await callInstall({ extensionData });
+    const result = await callOpen({ extensionData, path: 'options.html' });
 
     expect(result.isError).toBeFalsy();
     expect(mockInstall).toHaveBeenCalledWith({ extensionData });
-    expect(result.content[0].text).toContain('ext-123');
+    expect(mockUrl).toHaveBeenCalledWith('chrome-extension://ext-123/options.html');
+    expect(result.content[0].text).toContain('chrome-extension://ext-123/options.html');
   });
 
-  it('stores installed extension ids on session metadata', async () => {
+  it('strips leading slashes from the extension page path', async () => {
     setupSession();
-    await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+    await callOpen({ extensionData: { type: 'path', path: '/tmp/ext' }, path: '/options.html' });
+
+    expect(mockUrl).toHaveBeenCalledWith('chrome-extension://ext-123/options.html');
+  });
+
+  it('infers moz-extension URLs for Firefox', async () => {
+    setupSession({ browserName: 'firefox', isFirefox: true });
+    await callOpen({ extensionData: { type: 'path', path: '/tmp/ext' }, path: 'popup.html' });
+
+    expect(mockUrl).toHaveBeenCalledWith('moz-extension://ext-123/popup.html');
+  });
+
+  it('records the inferred moz-extension scheme for Firefox', async () => {
+    setupSession({ browserName: 'firefox', isFirefox: true });
+    const wrapped = withRecording('open_web_extension', openWebExtensionTool) as unknown as AnyToolFn;
+    await wrapped({ extensionData: { type: 'path', path: '/tmp/ext' }, path: 'popup.html' }, extra);
+
+    const steps = getSessionHistory().get('test-session')?.steps ?? [];
+    expect(steps[0]).toMatchObject({
+      tool: 'open_web_extension',
+      status: 'ok',
+      params: {
+        extensionData: { type: 'path', path: '/tmp/ext' },
+        path: 'popup.html',
+        scheme: 'moz-extension',
+      },
+    });
+  });
+
+  it('does not store extension ids on session metadata', async () => {
+    setupSession();
+    await callOpen({ extensionData: { type: 'path', path: '/tmp/ext' }, path: 'options.html' });
 
     const metadata = getState().sessionMetadata.get('test-session');
-    expect(metadata?.webExtensions).toEqual(['ext-123']);
+    expect(metadata).not.toHaveProperty('webExtensions');
   });
 
   it('returns an error when there is no active session', async () => {
-    const result = await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+    const result = await callOpen({ extensionData: { type: 'path', path: '/tmp/ext' }, path: 'options.html' });
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('No active browser session');
     expect(mockInstall).not.toHaveBeenCalled();
+    expect(mockUrl).not.toHaveBeenCalled();
   });
 
   it('returns an error for mobile sessions', async () => {
     setupSession({ type: 'ios' });
-    const result = await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+    const result = await callOpen({ extensionData: { type: 'path', path: '/tmp/ext' }, path: 'options.html' });
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('browser sessions');
     expect(mockInstall).not.toHaveBeenCalled();
+    expect(mockUrl).not.toHaveBeenCalled();
   });
 
   it('returns an error when the session is not BiDi-enabled', async () => {
     setupSession({ isBidi: false });
-    const result = await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+    const result = await callOpen({ extensionData: { type: 'path', path: '/tmp/ext' }, path: 'options.html' });
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('BiDi-enabled');
     expect(mockInstall).not.toHaveBeenCalled();
+    expect(mockUrl).not.toHaveBeenCalled();
   });
 
   it('returns an error when WebdriverIO does not expose webExtensionInstall', async () => {
     setupSession({ omitInstall: true });
-    const result = await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+    const result = await callOpen({ extensionData: { type: 'path', path: '/tmp/ext' }, path: 'options.html' });
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('webExtensionInstall');
+    expect(mockUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when webExtension.install returns an unexpected result', async () => {
+    setupSession();
+    mockInstall.mockResolvedValueOnce({});
+    const result = await callOpen({ extensionData: { type: 'path', path: '/tmp/ext' }, path: 'options.html' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('unexpected result');
+    expect(mockUrl).not.toHaveBeenCalled();
   });
 
   it('returns an error when the driver rejects installation', async () => {
     setupSession();
     mockInstall.mockRejectedValueOnce(new Error('invalid web extension'));
-    const result = await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+    const result = await callOpen({ extensionData: { type: 'path', path: '/tmp/ext' }, path: 'options.html' });
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('invalid web extension');
-  });
-});
-
-describe('uninstall_web_extension', () => {
-  it('calls webExtension.uninstall and removes the id from metadata', async () => {
-    setupSession({ webExtensions: ['ext-old', 'ext-123'] });
-    const result = await callUninstall({ extension: 'ext-123' });
-
-    expect(result.isError).toBeFalsy();
-    expect(mockUninstall).toHaveBeenCalledWith({ extension: 'ext-123' });
-    expect(getState().sessionMetadata.get('test-session')?.webExtensions).toEqual(['ext-old']);
-  });
-
-  it('returns an error when WebdriverIO does not expose webExtensionUninstall', async () => {
-    setupSession({ omitUninstall: true });
-    const result = await callUninstall({ extension: 'ext-123' });
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('webExtensionUninstall');
-  });
-});
-
-describe('open_web_extension_page', () => {
-  it('opens a direct extension URL when provided', async () => {
-    setupSession();
-    const url = 'chrome-extension://ext-123/options.html';
-    const result = await callOpen({ url, extension: 'ignored', path: 'ignored.html' });
-
-    expect(result.isError).toBeFalsy();
-    expect(mockUrl).toHaveBeenCalledWith(url);
-  });
-
-  it('opens the latest installed extension page by default', async () => {
-    setupSession({ webExtensions: ['ext-123'] });
-    const result = await callOpen({ path: '/options.html' });
-
-    expect(result.isError).toBeFalsy();
-    expect(mockUrl).toHaveBeenCalledWith('chrome-extension://ext-123/options.html');
-  });
-
-  it('infers moz-extension URLs for Firefox', async () => {
-    setupSession({ browserName: 'firefox', isFirefox: true, webExtensions: ['firefox-ext'] });
-    await callOpen({ path: 'popup.html' });
-
-    expect(mockUrl).toHaveBeenCalledWith('moz-extension://firefox-ext/popup.html');
-  });
-
-  it('records the inferred moz-extension scheme for Firefox', async () => {
-    setupSession({ browserName: 'firefox', isFirefox: true, webExtensions: ['firefox-ext'] });
-    const wrapped = withRecording('open_web_extension_page', openWebExtensionPageTool) as unknown as AnyToolFn;
-    await wrapped({ path: 'popup.html' }, extra);
-
-    const steps = getSessionHistory().get('test-session')?.steps ?? [];
-    expect(steps[0]).toMatchObject({
-      tool: 'open_web_extension_page',
-      status: 'ok',
-      params: { path: 'popup.html', scheme: 'moz-extension' },
-    });
-  });
-
-  it('uses explicit extension and scheme when provided', async () => {
-    setupSession();
-    await callOpen({ extension: 'ext-456', scheme: 'moz-extension', path: 'panel.html' });
-
-    expect(mockUrl).toHaveBeenCalledWith('moz-extension://ext-456/panel.html');
-  });
-
-  it('returns an error when no url or extension id is available', async () => {
-    setupSession();
-    const result = await callOpen({});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('provide url');
     expect(mockUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when navigation fails', async () => {
+    setupSession();
+    mockUrl.mockRejectedValueOnce(new Error('navigation blocked'));
+    const result = await callOpen({ extensionData: { type: 'path', path: '/tmp/ext' }, path: 'options.html' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('navigation blocked');
   });
 });

--- a/tests/tools/web-extension-tool.test.ts
+++ b/tests/tools/web-extension-tool.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getState } from '../../src/session/state';
+import {
+  installWebExtensionTool,
+  openWebExtensionPageTool,
+  uninstallWebExtensionTool,
+} from '../../src/tools/web-extension.tool';
+
+const mockInstall = vi.fn();
+const mockUninstall = vi.fn();
+const mockUrl = vi.fn();
+
+type ToolFn = (args: Record<string, unknown>) => Promise<{
+  content: { text: string }[];
+  isError?: boolean;
+}>;
+
+const callInstall = installWebExtensionTool as unknown as ToolFn;
+const callUninstall = uninstallWebExtensionTool as unknown as ToolFn;
+const callOpen = openWebExtensionPageTool as unknown as ToolFn;
+
+function setupSession(options: {
+  type?: 'browser' | 'ios' | 'android';
+  isBidi?: boolean;
+  browserName?: string;
+  isFirefox?: boolean;
+  webExtensions?: string[];
+  omitInstall?: boolean;
+  omitUninstall?: boolean;
+} = {}) {
+  const {
+    type = 'browser',
+    isBidi = true,
+    browserName = 'chrome',
+    isFirefox = false,
+    webExtensions,
+    omitInstall = false,
+    omitUninstall = false,
+  } = options;
+
+  const browser: Record<string, unknown> = {
+    isBidi,
+    isFirefox,
+    capabilities: { browserName },
+    url: mockUrl,
+  };
+
+  if (!omitInstall) {
+    browser.webExtensionInstall = mockInstall;
+  }
+  if (!omitUninstall) {
+    browser.webExtensionUninstall = mockUninstall;
+  }
+
+  const state = getState();
+  state.currentSession = 'test-session';
+  state.browsers.set('test-session', browser as unknown as WebdriverIO.Browser);
+  state.sessionMetadata.set('test-session', {
+    type,
+    capabilities: { browserName },
+    isAttached: false,
+    ...(webExtensions ? { webExtensions } : {}),
+  });
+  state.sessionHistory.set('test-session', {
+    sessionId: 'test-session',
+    type,
+    startedAt: '2026-01-01T00:00:00.000Z',
+    capabilities: { browserName },
+    steps: [],
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInstall.mockResolvedValue({ extension: 'ext-123' });
+  mockUninstall.mockResolvedValue(null);
+  mockUrl.mockResolvedValue(undefined);
+
+  const state = getState();
+  state.browsers.clear();
+  state.sessionMetadata.clear();
+  state.sessionHistory.clear();
+  state.currentSession = null;
+});
+
+describe('install_web_extension', () => {
+  it.each([
+    { type: 'path', path: '/tmp/unpacked-extension' },
+    { type: 'archivePath', path: '/tmp/extension.zip' },
+    { type: 'base64', value: 'UEsDBAo=' },
+  ])('passes %s extensionData to webExtension.install', async (extensionData) => {
+    setupSession();
+    const result = await callInstall({ extensionData });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockInstall).toHaveBeenCalledWith({ extensionData });
+    expect(result.content[0].text).toContain('ext-123');
+  });
+
+  it('stores installed extension ids on session metadata', async () => {
+    setupSession();
+    await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+
+    const metadata = getState().sessionMetadata.get('test-session');
+    expect(metadata?.webExtensions).toEqual(['ext-123']);
+  });
+
+  it('returns an error when there is no active session', async () => {
+    const result = await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('No active browser session');
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  it('returns an error for mobile sessions', async () => {
+    setupSession({ type: 'ios' });
+    const result = await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('browser sessions');
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the session is not BiDi-enabled', async () => {
+    setupSession({ isBidi: false });
+    const result = await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('BiDi-enabled');
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when WebdriverIO does not expose webExtensionInstall', async () => {
+    setupSession({ omitInstall: true });
+    const result = await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('webExtensionInstall');
+  });
+
+  it('returns an error when the driver rejects installation', async () => {
+    setupSession();
+    mockInstall.mockRejectedValueOnce(new Error('invalid web extension'));
+    const result = await callInstall({ extensionData: { type: 'path', path: '/tmp/ext' } });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid web extension');
+  });
+});
+
+describe('uninstall_web_extension', () => {
+  it('calls webExtension.uninstall and removes the id from metadata', async () => {
+    setupSession({ webExtensions: ['ext-old', 'ext-123'] });
+    const result = await callUninstall({ extension: 'ext-123' });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockUninstall).toHaveBeenCalledWith({ extension: 'ext-123' });
+    expect(getState().sessionMetadata.get('test-session')?.webExtensions).toEqual(['ext-old']);
+  });
+
+  it('returns an error when WebdriverIO does not expose webExtensionUninstall', async () => {
+    setupSession({ omitUninstall: true });
+    const result = await callUninstall({ extension: 'ext-123' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('webExtensionUninstall');
+  });
+});
+
+describe('open_web_extension_page', () => {
+  it('opens a direct extension URL when provided', async () => {
+    setupSession();
+    const url = 'chrome-extension://ext-123/options.html';
+    const result = await callOpen({ url, extension: 'ignored', path: 'ignored.html' });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockUrl).toHaveBeenCalledWith(url);
+  });
+
+  it('opens the latest installed extension page by default', async () => {
+    setupSession({ webExtensions: ['ext-123'] });
+    const result = await callOpen({ path: '/options.html' });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockUrl).toHaveBeenCalledWith('chrome-extension://ext-123/options.html');
+  });
+
+  it('infers moz-extension URLs for Firefox', async () => {
+    setupSession({ browserName: 'firefox', isFirefox: true, webExtensions: ['firefox-ext'] });
+    await callOpen({ path: 'popup.html' });
+
+    expect(mockUrl).toHaveBeenCalledWith('moz-extension://firefox-ext/popup.html');
+  });
+
+  it('uses explicit extension and scheme when provided', async () => {
+    setupSession();
+    await callOpen({ extension: 'ext-456', scheme: 'moz-extension', path: 'panel.html' });
+
+    expect(mockUrl).toHaveBeenCalledWith('moz-extension://ext-456/panel.html');
+  });
+
+  it('returns an error when no url or extension id is available', async () => {
+    setupSession();
+    const result = await callOpen({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('provide url');
+    expect(mockUrl).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/web-extension-tool.test.ts
+++ b/tests/tools/web-extension-tool.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp';
 import { getState } from '../../src/session/state';
+import { getSessionHistory, withRecording } from '../../src/recording/step-recorder';
 import {
   installWebExtensionTool,
   openWebExtensionPageTool,
@@ -14,10 +16,12 @@ type ToolFn = (args: Record<string, unknown>) => Promise<{
   content: { text: string }[];
   isError?: boolean;
 }>;
+type AnyToolFn = (params: Record<string, unknown>, extra: unknown) => Promise<unknown>;
 
 const callInstall = installWebExtensionTool as unknown as ToolFn;
 const callUninstall = uninstallWebExtensionTool as unknown as ToolFn;
 const callOpen = openWebExtensionPageTool as unknown as ToolFn;
+const extra = {} as Parameters<ToolCallback>[1];
 
 function setupSession(options: {
   type?: 'browser' | 'ios' | 'android';
@@ -191,6 +195,19 @@ describe('open_web_extension_page', () => {
     await callOpen({ path: 'popup.html' });
 
     expect(mockUrl).toHaveBeenCalledWith('moz-extension://firefox-ext/popup.html');
+  });
+
+  it('records the inferred moz-extension scheme for Firefox', async () => {
+    setupSession({ browserName: 'firefox', isFirefox: true, webExtensions: ['firefox-ext'] });
+    const wrapped = withRecording('open_web_extension_page', openWebExtensionPageTool) as unknown as AnyToolFn;
+    await wrapped({ path: 'popup.html' }, extra);
+
+    const steps = getSessionHistory().get('test-session')?.steps ?? [];
+    expect(steps[0]).toMatchObject({
+      tool: 'open_web_extension_page',
+      status: 'ok',
+      params: { path: 'popup.html', scheme: 'moz-extension' },
+    });
   });
 
   it('uses explicit extension and scheme when provided', async () => {


### PR DESCRIPTION
## Proposed changes

Add BiDi-based web extension support to the MCP server.

This introduces three new tools for browser sessions with `webSocketUrl: true`:
- `install_web_extension` to install unpacked, archived, or base64-encoded extensions
- `uninstall_web_extension` to remove an installed extension by id
- `open_web_extension_page` to navigate to an extension page so standard page tools can
inspect and drive it

The change also tracks installed extension ids in session metadata, wires the new tools into
recording/code generation, updates trace tool mapping, and adds README examples for BiDi
extension workflows.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
expected)
- [x] Documentation update (improvements to the project's docs)
- [x] Internal updates (everything related to internal scripts, governance documentation and
CI files)

## Checklist

- [x] I have squashed commits that belong together
- [x] I have tested with Claude Desktop (or another MCP-compatible client)
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/
CONTRIBUTING.md) doc
- [x] I have added the necessary documentation for new/changed tools (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

The implementation is intentionally scoped to BiDi-capable browser sessions. For remote/cloud
sessions, `base64` extension payloads are supported so the driver does not need access to the
MCP server filesystem.

Tested using OpenCode against Bitwarden web extension

<img width="1915" height="1031" alt="extension-install-step" src="https://github.com/user-attachments/assets/c7c08405-1a43-44ce-8889-a150b0ab97e3" />


Recording support mirrors the live tools, including replay of extension install/uninstall
calls and extension-page navigation.

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
