### PR TITLE
feat: add external WebDriver provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,8 @@ Both tools require a `provider` parameter (`'browserstack'`, `'saucelabs'`, `'te
 - **Scrolling**: Smooth scrolling with configurable distances
 - **Attach to running Chrome**: Connect to an existing Chrome window via `--remote-debugging-port` — ideal for testing
   authenticated or pre-configured sessions
+- **Connect to existing WebDriver endpoints**: Reuse an already-running Selenium-compatible WebDriver endpoint, such as
+  a framework-managed browser or a desktop webview automation bridge (like Tauri)
 - **Device emulation**: Apply mobile/tablet presets (iPhone 15, Pixel 7, etc.) to simulate responsive layouts without a
   physical device
 - **Session Recording**: All tool calls are automatically recorded and exportable as runnable WebdriverIO JS
@@ -700,7 +702,7 @@ Both tools require a `provider` parameter (`'browserstack'`, `'saucelabs'`, `'te
 
 | Tool             | Description                                                                                                                                                            |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `start_session`  | Start a browser or app session. Use `platform: 'browser'` for web, `platform: 'ios'`/`'android'` for mobile, or `attach: true` to connect to a running Chrome instance |
+| `start_session`  | Start a browser or app session. Use `platform: 'browser'` for web, `platform: 'ios'`/`'android'` for mobile, `attach: true` to connect to a running Chrome instance, or `provider: 'external'` to connect to an existing WebDriver endpoint |
 | `launch_chrome`  | Launch a new Chrome instance with remote debugging enabled (for use with `start_session({ attach: true })`)                                                            |
 | `close_session`  | Close or detach from the current session (supports `detach: true` to disconnect without terminating)                                                                   |
 | `emulate_device` | Emulate a mobile/tablet device preset (viewport, DPR, UA, touch); requires BiDi session                                                                                |
@@ -874,6 +876,37 @@ start_session({attach: true})
 start_session({attach: true, port: 9333})
 start_session({attach: true, port: 9222, navigationUrl: 'https://app.example.com'})
 ```
+
+**Connect to an existing WebDriver endpoint:**
+
+Use `provider: 'external'` when another process already owns the browser or webview lifecycle and exposes a W3C
+WebDriver endpoint. This is useful for Selenium Grid sessions, externally managed browser drivers, or desktop apps like Tauri apps that
+embed a webview and expose WebDriver separately. The MCP server connects to the endpoint; it does not launch or stop the
+target application, start tunnels, or manage framework-specific setup.
+
+```javascript
+// Defaults to http://127.0.0.1:4445/ and browserName: 'chrome'
+start_session({provider: 'external', platform: 'browser'})
+
+// Custom WebDriver endpoint and capabilities
+start_session({
+    provider: 'external',
+    platform: 'browser',
+    webdriverConfig: {
+        protocol: 'http',
+        hostname: '127.0.0.1',
+        port: 4445,
+        path: '/'
+    },
+    capabilities: {
+        browserName: 'tauri'
+    }
+})
+```
+
+For desktop webview apps such as Tauri, first start the app and its WebDriver bridge outside of this MCP server, then
+pass the endpoint and the required capabilities. For example, a Tauri WebDriver bridge may require
+`capabilities: {browserName: 'tauri'}`.
 
 **Device emulation (requires BiDi session):**
 

--- a/src/providers/external.provider.ts
+++ b/src/providers/external.provider.ts
@@ -1,0 +1,44 @@
+import type { ConnectionConfig, SessionProvider } from './types';
+
+export type ExternalProviderOptions = {
+  webdriverConfig?: {
+    protocol?: string;
+    hostname?: string;
+    port?: number;
+    path?: string;
+  };
+  browser?: string;
+  capabilities?: Record<string, unknown>;
+};
+
+export class ExternalProvider implements SessionProvider {
+  name = 'external';
+
+  getConnectionConfig(options: Record<string, unknown>): ConnectionConfig {
+    const config = options.webdriverConfig as ExternalProviderOptions['webdriverConfig'] | undefined;
+    return {
+      protocol: config?.protocol ?? 'http',
+      hostname: config?.hostname ?? '127.0.0.1',
+      port: config?.port ?? 4445,
+      path: config?.path ?? '/',
+    };
+  }
+
+  buildCapabilities(options: Record<string, unknown>): Record<string, unknown> {
+    const userCapabilities = (options.capabilities as Record<string, unknown> | undefined) ?? {};
+    return {
+      browserName: (options.browser as string | undefined) ?? 'chrome',
+      ...userCapabilities,
+    };
+  }
+
+  getSessionType(_options: Record<string, unknown>): 'browser' {
+    return 'browser';
+  }
+
+  shouldAutoDetach(_options: Record<string, unknown>): boolean {
+    return true;
+  }
+}
+
+export const externalProvider = new ExternalProvider();

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -6,6 +6,7 @@ import { sauceLabsProvider } from './cloud/saucelabs.provider';
 import { testMuProvider } from './cloud/testmu.provider';
 import { testingBotProvider } from './cloud/testingbot.provider';
 import { digitalAiProvider } from './cloud/digitalai.provider';
+import { externalProvider } from './external.provider';
 
 const providers = new Map<string, SessionProvider>([
   ['browserstack', browserStackProvider],
@@ -13,6 +14,7 @@ const providers = new Map<string, SessionProvider>([
   ['testmu', testMuProvider],
   ['testingbot', testingBotProvider],
   ['digitalai', digitalAiProvider],
+  ['external', externalProvider],
 ]);
 
 function getDefaultProvider(platform: string): SessionProvider {

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -87,9 +87,11 @@ export function registerSession(
           await provider.onSessionClose?.(oldSessionId, oldMetadata.type, getSessionResult(oldHistory), oldMetadata.tunnelHandle, oldBrowser, oldMetadata.region).catch(() => {
           });
         }
-        await oldBrowser.deleteSession().catch(() => {
-          // Ignore errors during force-close of orphaned session
-        });
+        if (!oldMetadata?.isAttached) {
+          await oldBrowser.deleteSession().catch(() => {
+            // Ignore errors during force-close of orphaned session
+          });
+        }
         if (oldMetadata?.provider && oldMetadata?.tunnelHandle) {
           const provider = getProvider(oldMetadata.provider, oldMetadata.type);
           await provider.stopTunnel?.(oldMetadata.tunnelHandle).catch(() => {});

--- a/src/session/state.ts
+++ b/src/session/state.ts
@@ -4,7 +4,7 @@ export interface SessionMetadata {
   type: 'browser' | 'ios' | 'android';
   capabilities: Record<string, unknown>;
   isAttached: boolean;
-  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot' | 'digitalai';
+  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot' | 'digitalai' | 'external';
   region?: string;
   tunnelName?: string;
   tunnelHandle?: unknown;

--- a/src/tools/session.tool.ts
+++ b/src/tools/session.tool.ts
@@ -19,7 +19,7 @@ export const startSessionToolDefinition: ToolDefinition = {
   description: 'Starts a browser or mobile automation session. Only one active session at a time — starting a new one closes the existing session first. Use platform "browser" with a browser name, or "ios"/"android" with deviceName. Set attach: true to connect to a running Chrome via CDP instead of launching a new browser.',
   annotations: { title: 'Start Session', destructiveHint: false },
   inputSchema: {
-    provider: z.enum(['local', 'browserstack', 'saucelabs', 'testmu', 'testingbot', 'digitalai']).optional().default('local').describe('Session provider (default: local). "digitalai" requires DIGITALAI_CLOUD_URL + DIGITALAI_ACCESS_KEY env vars.'),
+    provider: z.enum(['local', 'browserstack', 'saucelabs', 'testmu', 'testingbot', 'digitalai', 'external']).optional().default('local').describe('Session provider (default: local). Use "external" to connect to an externally managed W3C WebDriver endpoint. "digitalai" requires DIGITALAI_CLOUD_URL + DIGITALAI_ACCESS_KEY env vars.'),
     platform: platformEnum.describe('Session platform type'),
     browser: browserEnum.optional().describe('Browser to launch (required for browser platform)'),
     browserVersion: z.string().optional().describe('Browser version (cloud providers only, default: latest)'),
@@ -53,6 +53,12 @@ export const startSessionToolDefinition: ToolDefinition = {
       port: z.number().optional().default(9222),
       host: z.string().optional().default('localhost'),
     }).optional().describe('Chrome remote debugging connection (attach mode only, defaults: port 9222, host localhost)'),
+    webdriverConfig: z.object({
+      protocol: z.string().optional().default('http'),
+      hostname: z.string().optional().default('127.0.0.1'),
+      port: z.number().optional().default(4445),
+      path: z.string().optional().default('/'),
+    }).optional().describe('Existing W3C WebDriver endpoint connection (provider: "external" only). Defaults to 127.0.0.1:4445/.'),
     appiumConfig: z.object({
       host: z.string().optional(),
       port: z.number().optional(),
@@ -71,7 +77,7 @@ export const startSessionToolDefinition: ToolDefinition = {
 };
 
 type StartSessionArgs = {
-  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot' | 'digitalai';
+  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot' | 'digitalai' | 'external';
   platform: 'browser' | 'ios' | 'android';
   browser?: 'chrome' | 'firefox' | 'edge' | 'safari';
   browserVersion?: string;
@@ -98,6 +104,7 @@ type StartSessionArgs = {
   trace?: boolean;
   attach?: boolean;
   attachConfig?: { port?: number; host?: string };
+  webdriverConfig?: { protocol?: string; hostname?: string; port?: number; path?: string };
   appiumConfig?: { host?: string; port?: number; path?: string; protocol?: string };
   region?: 'us-west-1' | 'eu-central-1' | 'apac-southeast-1';
   tunnel?: boolean | 'external';
@@ -218,11 +225,12 @@ async function startBrowserSession(args: StartSessionArgs): Promise<CallToolResu
 
   const wdioBrowser = await remote({ ...connectionConfig, capabilities: mergedCapabilities });
   const { sessionId } = wdioBrowser;
+  const shouldAutoDetach = provider.shouldAutoDetach(args as Record<string, unknown>);
 
   const sessionMetadata: SessionMetadata = {
     type: 'browser',
     capabilities: mergedCapabilities,
-    isAttached: false,
+    isAttached: shouldAutoDetach,
     provider: args.provider ?? 'local',
     region: args.region,
     tunnelName,
@@ -262,11 +270,20 @@ async function startBrowserSession(args: StartSessionArgs): Promise<CallToolResu
     ? '\nNote: Safari does not support headless mode. Started in headed mode.'
     : '';
   const reportNote = provider.getStartNote?.(wdioBrowser) ?? '';
+  const startMessage = args.provider === 'external'
+    ? [
+      `Connected to externally managed WebDriver endpoint with sessionId: ${sessionId}`,
+      `Endpoint: ${connectionConfig.protocol ?? 'http'}://${connectionConfig.hostname ?? '127.0.0.1'}:${connectionConfig.port ?? 4445}${connectionConfig.path ?? '/'}`,
+      `Capabilities: ${JSON.stringify(mergedCapabilities)}`,
+      sizeNote.trim(),
+      reportNote.trim(),
+    ].filter(Boolean).join('\n')
+    : `${browserDisplayNames[browser]} browser started in ${modeText} mode with sessionId: ${sessionId} (${windowWidth}x${windowHeight})${urlText}${headlessNote}${sizeNote}${reportNote}`;
 
   return {
     content: [{
       type: 'text',
-      text: `${browserDisplayNames[browser]} browser started in ${modeText} mode with sessionId: ${sessionId} (${windowWidth}x${windowHeight})${urlText}${headlessNote}${sizeNote}${reportNote}`,
+      text: startMessage,
     }],
   };
 }
@@ -422,6 +439,13 @@ async function attachBrowserSession(args: StartSessionArgs): Promise<CallToolRes
 
 export const startSessionTool: ToolCallback = async (args: StartSessionArgs): Promise<CallToolResult> => {
   try {
+    if (args.provider === 'external' && args.platform !== 'browser') {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: 'Error starting session: provider "external" currently supports browser platform sessions only.' }],
+      };
+    }
+
     if (args.platform === 'browser') {
       if (args.attach) {
         return await attachBrowserSession(args);
@@ -442,7 +466,7 @@ export const closeSessionTool: ToolCallback = async (args: { detach?: boolean } 
     const metadata = state.sessionMetadata.get(sessionId);
 
     const isAttached = !!metadata?.isAttached;
-    const detach = args.detach ?? false;
+    const detach = args.detach ?? metadata?.provider === 'external';
 
     // Determine if this is a force-close (auto-detached session + explicit close)
     const force = !detach && isAttached;

--- a/tests/providers/external.provider.test.ts
+++ b/tests/providers/external.provider.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { ExternalProvider } from '../../src/providers/external.provider';
+
+describe('ExternalProvider', () => {
+  const provider = new ExternalProvider();
+
+  it('defaults to a local WebDriver endpoint', () => {
+    expect(provider.getConnectionConfig({})).toEqual({
+      protocol: 'http',
+      hostname: '127.0.0.1',
+      port: 4445,
+      path: '/',
+    });
+  });
+
+  it('uses the provided WebDriver endpoint config', () => {
+    expect(provider.getConnectionConfig({
+      webdriverConfig: {
+        protocol: 'https',
+        hostname: 'webdriver.example.test',
+        port: 443,
+        path: '/wd/hub',
+      },
+    })).toEqual({
+      protocol: 'https',
+      hostname: 'webdriver.example.test',
+      port: 443,
+      path: '/wd/hub',
+    });
+  });
+
+  it('defaults browserName to chrome and allows user capabilities to override it', () => {
+    expect(provider.buildCapabilities({})).toEqual({ browserName: 'chrome' });
+    expect(provider.buildCapabilities({
+      capabilities: {
+        browserName: 'tauri',
+        webSocketUrl: true,
+      },
+    })).toEqual({
+      browserName: 'tauri',
+      webSocketUrl: true,
+    });
+  });
+
+  it('reports browser session semantics', () => {
+    expect(provider.getSessionType({})).toBe('browser');
+    expect(provider.shouldAutoDetach({})).toBe(true);
+  });
+});

--- a/tests/providers/registry.test.ts
+++ b/tests/providers/registry.test.ts
@@ -6,6 +6,7 @@ import { BrowserStackProvider } from '../../src/providers/cloud/browserstack.pro
 import { TestMuProvider } from '../../src/providers/cloud/testmu.provider';
 import { TestingBotProvider } from '../../src/providers/cloud/testingbot.provider';
 import { DigitalAiProvider } from '../../src/providers/cloud/digitalai.provider';
+import { ExternalProvider } from '../../src/providers/external.provider';
 
 describe('getProvider', () => {
   it('returns LocalBrowserProvider for local browser', () => {
@@ -66,6 +67,10 @@ describe('getProvider', () => {
 
   it('returns DigitalAiProvider for digitalai ios', () => {
     expect(getProvider('digitalai', 'ios')).toBeInstanceOf(DigitalAiProvider);
+  });
+
+  it('returns ExternalProvider for external browser', () => {
+    expect(getProvider('external', 'browser')).toBeInstanceOf(ExternalProvider);
   });
 
   it('defaults to local when provider is undefined', () => {

--- a/tests/session/lifecycle.test.ts
+++ b/tests/session/lifecycle.test.ts
@@ -84,6 +84,26 @@ describe('registerSession', () => {
     expect(mockOnSessionClose).toHaveBeenCalledWith('s1', 'browser', { status: 'passed' }, tunnel, expect.any(Object), undefined);
   });
 
+  it('does not delete an auto-detached previous session during session transition', async () => {
+    const state = getState();
+    const oldBrowser = makeBrowser();
+    const oldMeta: SessionMetadata = { type: 'browser', capabilities: {}, isAttached: true, provider: 'external' };
+    const h1: SessionHistory = { sessionId: 's1', type: 'browser', startedAt: new Date().toISOString(), capabilities: {}, steps: [] };
+    state.browsers.set('s1', oldBrowser);
+    state.sessionMetadata.set('s1', oldMeta);
+    state.sessionHistory.set('s1', h1);
+    state.currentSession = 's1';
+
+    const newMeta: SessionMetadata = { type: 'browser', capabilities: {}, isAttached: false };
+    const h2: SessionHistory = { sessionId: 's2', type: 'browser', startedAt: new Date().toISOString(), capabilities: {}, steps: [] };
+    registerSession('s2', makeBrowser(), newMeta, h2);
+
+    // Allow fire-and-forget cleanup to complete
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(oldBrowser.deleteSession).not.toHaveBeenCalled();
+  });
+
   it('appends session_transition to previous session', () => {
     const state = getState();
     const meta: SessionMetadata = { type: 'browser', capabilities: {}, isAttached: false };

--- a/tests/tools/close-session.test.ts
+++ b/tests/tools/close-session.test.ts
@@ -4,6 +4,7 @@ import type { SessionHistory } from '../../src/types/recording';
 // No mock of browser.tool — closeSessionTool reads from the module-level state directly.
 // We inject test sessions via getState(), which IS the module-level state object.
 import { closeSessionTool } from '../../src/tools/session.tool';
+import type { SessionMetadata } from '../../src/session/state';
 import { getState } from '../../src/session/state';
 
 type ToolFn = (args: Record<string, unknown>) => Promise<{ content: { text: string }[] }>;
@@ -11,11 +12,11 @@ const callClose = closeSessionTool as unknown as ToolFn;
 
 const mockDeleteSession = vi.fn();
 
-function setupSession(sessionId: string, isAttached: boolean) {
+function setupSession(sessionId: string, isAttached: boolean, metadata: Partial<SessionMetadata> = {}) {
   const state = getState();
   state.browsers.set(sessionId, { deleteSession: mockDeleteSession } as unknown as WebdriverIO.Browser);
   state.currentSession = sessionId;
-  state.sessionMetadata.set(sessionId, { type: 'browser', capabilities: {}, isAttached });
+  state.sessionMetadata.set(sessionId, { type: 'browser', capabilities: {}, isAttached, ...metadata });
   state.sessionHistory.set(sessionId, {
     sessionId,
     type: 'browser',
@@ -63,6 +64,22 @@ describe('close_session', () => {
     setupSession('sess-attached', true);
     const result = await callClose({ detach: true });
     expect(result.content[0].text).toContain('detached from');
+  });
+
+  it('detaches external sessions by default without deleting the externally managed session', async () => {
+    setupSession('sess-external', true, { provider: 'external' });
+    const result = await callClose({});
+
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('detached from');
+  });
+
+  it('force-closes external sessions when detach is explicitly false', async () => {
+    setupSession('sess-external', true, { provider: 'external' });
+    const result = await callClose({ detach: false });
+
+    expect(mockDeleteSession).toHaveBeenCalledOnce();
+    expect(result.content[0].text).toContain('closed');
   });
 
   it('cleans up local state in both cases', async () => {

--- a/tests/tools/start-session-external.test.ts
+++ b/tests/tools/start-session-external.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { remote } from 'webdriverio';
+import { startSessionTool, startSessionToolDefinition } from '../../src/tools/session.tool';
+import { registerSession } from '../../src/session/lifecycle';
+
+vi.mock('webdriverio', () => ({
+  remote: vi.fn().mockResolvedValue({
+    sessionId: 'external-session-id',
+    capabilities: {},
+    setWindowSize: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/session/lifecycle', () => ({
+  registerSession: vi.fn(),
+}));
+
+vi.mock('../../src/session/state', () => ({
+  getState: vi.fn(() => ({
+    browsers: new Map(),
+    currentSession: null,
+    sessionMetadata: new Map(),
+    sessionHistory: new Map(),
+  })),
+}));
+
+type ToolFn = (args: Record<string, unknown>) => Promise<{ content: { text: string }[]; isError?: boolean }>;
+const callTool = startSessionTool as unknown as ToolFn;
+const mockRemote = remote as ReturnType<typeof vi.fn>;
+const mockRegisterSession = registerSession as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRemote.mockResolvedValue({
+    sessionId: 'external-session-id',
+    capabilities: {},
+    setWindowSize: vi.fn(),
+  });
+});
+
+describe('start_session with provider: external', () => {
+  it('exposes external provider and endpoint config in the tool schema', () => {
+    const providerSchema = startSessionToolDefinition.inputSchema.provider as unknown as {
+      safeParse: (value: unknown) => { success: boolean };
+    };
+    const webdriverConfigSchema = startSessionToolDefinition.inputSchema.webdriverConfig as unknown as {
+      safeParse: (value: unknown) => { success: boolean };
+    };
+
+    expect(providerSchema.safeParse('external').success).toBe(true);
+    expect(webdriverConfigSchema.safeParse({
+      protocol: 'http',
+      hostname: '127.0.0.1',
+      port: 4445,
+      path: '/',
+    }).success).toBe(true);
+  });
+
+  it('connects to an existing WebDriver endpoint for browser sessions', async () => {
+    const result = await callTool({
+      provider: 'external',
+      platform: 'browser',
+      webdriverConfig: {
+        protocol: 'http',
+        hostname: '127.0.0.1',
+        port: 4445,
+        path: '/',
+      },
+      capabilities: {
+        browserName: 'tauri',
+      },
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockRemote).toHaveBeenCalledWith(expect.objectContaining({
+      protocol: 'http',
+      hostname: '127.0.0.1',
+      port: 4445,
+      path: '/',
+      capabilities: expect.objectContaining({
+        browserName: 'tauri',
+      }),
+    }));
+    expect(result.content[0].text).toContain(
+      'Connected to externally managed WebDriver endpoint with sessionId: external-session-id',
+    );
+    expect(result.content[0].text).toContain('Endpoint: http://127.0.0.1:4445/');
+  });
+
+  it('registers external sessions as attached so close_session detaches by default', async () => {
+    await callTool({
+      provider: 'external',
+      platform: 'browser',
+    });
+
+    expect(mockRegisterSession).toHaveBeenCalledWith(
+      'external-session-id',
+      expect.any(Object),
+      expect.objectContaining({
+        provider: 'external',
+        isAttached: true,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('rejects mobile platform sessions instead of silently using browser semantics', async () => {
+    const result = await callTool({
+      provider: 'external',
+      platform: 'android',
+      deviceName: 'Pixel 7',
+      noReset: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('provider "external" currently supports browser platform sessions only');
+    expect(mockRemote).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Proposed changes

Add an `external` session provider that connects `@wdio/mcp` to an already-running W3C WebDriver endpoint.

This is useful for Selenium Grid-compatible infrastructure, manually managed browser drivers, and desktop webview automation bridges such as Tauri WebDriver integrations.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have squashed commits that belong together
- [x] I have tested with Claude Desktop (or another MCP-compatible client)
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added the necessary documentation for new/changed tools (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

I tested this with Codex against a Tauri app I am developing using `@wdio/tauri-plugin` and `@wdio/tauri-service`; the MCP server connected to the app's embedded WebDriver endpoint and controlled the real app UI.