### PR TITLE
feat: attach to existing WebDriver sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,8 @@ Both tools require a `provider` parameter (`'browserstack'`, `'saucelabs'`, `'te
 
 | Tool             | Description                                                                                                                                                            |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `start_session`  | Start or attach to a browser or app session. Use `sessionId` for an existing remote WebDriver/Appium session, `attach: true` for a running Chrome instance over CDP, or omit both to create a session |
+| `start_session`  | Start a new browser or app session; `attach: true` retains the existing Chrome CDP connection mode                                                                         |
+| `attach_session` | Attach to an existing remote WebDriver/Appium session by ID without creating a new session                                                                                   |
 | `launch_chrome`  | Launch a new Chrome instance with remote debugging enabled (for use with `start_session({ attach: true })`)                                                            |
 | `close_session`  | Close or detach from the current session (supports `detach: true` to disconnect without terminating)                                                                   |
 | `emulate_device` | Emulate a mobile/tablet device preset (viewport, DPR, UA, touch); requires BiDi session                                                                                |
@@ -923,14 +924,14 @@ pass the endpoint and the required capabilities. For example, a Tauri WebDriver 
 
 **Attach to an existing WebDriver or Appium session:**
 
-Pass `sessionId` when the session has already been created by another process. The MCP reuses the selected provider's
+Use `attach_session` when the session has already been created by another process. The MCP reuses the selected provider's
 endpoint and credentials, registers the appropriate browser/mobile command set locally, and does not issue a new-session
 request. Attached sessions are externally managed: `close_session()` detaches by default, while
 `close_session({detach: false})` explicitly terminates the remote session.
 
 ```javascript
 // Existing BrowserStack App Automate session
-start_session({
+attach_session({
     provider: 'browserstack',
     platform: 'ios',
     sessionId: 'existing-browserstack-session-id',
@@ -941,7 +942,7 @@ start_session({
 })
 
 // Existing session on a local Appium server
-start_session({
+attach_session({
     provider: 'local',
     platform: 'android',
     sessionId: 'existing-appium-session-id',
@@ -954,7 +955,7 @@ start_session({
 })
 
 // Existing mobile session on a custom W3C WebDriver endpoint
-start_session({
+attach_session({
     provider: 'external',
     platform: 'ios',
     sessionId: 'existing-grid-session-id',
@@ -967,9 +968,8 @@ start_session({
 })
 ```
 
-An existing cloud session must keep using the tunnel it was created with. `tunnel: true` is therefore rejected while
-attaching; keep the original tunnel process alive and use `tunnel: 'external'` when the provider configuration needs the
-tunnel capability metadata.
+An existing cloud session must keep using the tunnel it was created with. `attach_session` never starts or stops a tunnel,
+so keep the original tunnel process alive for as long as the session needs it.
 
 **Device emulation (requires BiDi session):**
 
@@ -1084,7 +1084,7 @@ Test my hybrid app:
 - Use `close_session({ detach: true })` to disconnect without terminating the session on the Appium server
 - **State preservation** can be controlled with `noReset` and `fullReset` parameters during session creation
 - Sessions created with `noReset: true` or without `appPath` will automatically detach on close
-- Sessions attached with `sessionId` always detach on close unless `detach: false` is explicitly requested
+- Sessions adopted with `attach_session` always detach on close unless `detach: false` is explicitly requested
 
 ⚠️ **Task Planning:**
 
@@ -1154,12 +1154,12 @@ Appium server:
 // Detach without killing the session
 close_session({detach: true})
 
-// Standard session termination (closes the app and removes session)
-close_session({detach: false})  // or just close_session()
+// Explicit session termination (closes the app and removes session)
+close_session({detach: false})
 ```
 
 Sessions created with `noReset: true` or without `appPath` will automatically detach on close.
-Sessions attached by `sessionId` are externally managed and also detach by default; pass `detach: false` only when the
+Sessions adopted with `attach_session` are externally managed and also detach by default; pass `detach: false` only when the
 MCP should deliberately terminate the existing remote session.
 
 This is particularly useful when:

--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ Both tools require a `provider` parameter (`'browserstack'`, `'saucelabs'`, `'te
 
 | Tool             | Description                                                                                                                                                            |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `start_session`  | Start a browser or app session. Use `platform: 'browser'` for web, `platform: 'ios'`/`'android'` for mobile, `attach: true` to connect to a running Chrome instance, or `provider: 'external'` to connect to an existing WebDriver endpoint |
+| `start_session`  | Start or attach to a browser or app session. Use `sessionId` for an existing remote WebDriver/Appium session, `attach: true` for a running Chrome instance over CDP, or omit both to create a session |
 | `launch_chrome`  | Launch a new Chrome instance with remote debugging enabled (for use with `start_session({ attach: true })`)                                                            |
 | `close_session`  | Close or detach from the current session (supports `detach: true` to disconnect without terminating)                                                                   |
 | `emulate_device` | Emulate a mobile/tablet device preset (viewport, DPR, UA, touch); requires BiDi session                                                                                |
@@ -921,6 +921,56 @@ For desktop webview apps such as Tauri, first start the app and its WebDriver br
 pass the endpoint and the required capabilities. For example, a Tauri WebDriver bridge may require
 `capabilities: {browserName: 'tauri'}`.
 
+**Attach to an existing WebDriver or Appium session:**
+
+Pass `sessionId` when the session has already been created by another process. The MCP reuses the selected provider's
+endpoint and credentials, registers the appropriate browser/mobile command set locally, and does not issue a new-session
+request. Attached sessions are externally managed: `close_session()` detaches by default, while
+`close_session({detach: false})` explicitly terminates the remote session.
+
+```javascript
+// Existing BrowserStack App Automate session
+start_session({
+    provider: 'browserstack',
+    platform: 'ios',
+    sessionId: 'existing-browserstack-session-id',
+    capabilities: {
+        'appium:deviceName': 'iPhone 15',
+        'appium:automationName': 'XCUITest'
+    }
+})
+
+// Existing session on a local Appium server
+start_session({
+    provider: 'local',
+    platform: 'android',
+    sessionId: 'existing-appium-session-id',
+    appiumConfig: {
+        protocol: 'http',
+        host: '127.0.0.1',
+        port: 4723,
+        path: '/'
+    }
+})
+
+// Existing mobile session on a custom W3C WebDriver endpoint
+start_session({
+    provider: 'external',
+    platform: 'ios',
+    sessionId: 'existing-grid-session-id',
+    webdriverConfig: {
+        protocol: 'https',
+        hostname: 'grid.example.com',
+        port: 443,
+        path: '/wd/hub'
+    }
+})
+```
+
+An existing cloud session must keep using the tunnel it was created with. `tunnel: true` is therefore rejected while
+attaching; keep the original tunnel process alive and use `tunnel: 'external'` when the provider configuration needs the
+tunnel capability metadata.
+
 **Device emulation (requires BiDi session):**
 
 ```
@@ -1034,6 +1084,7 @@ Test my hybrid app:
 - Use `close_session({ detach: true })` to disconnect without terminating the session on the Appium server
 - **State preservation** can be controlled with `noReset` and `fullReset` parameters during session creation
 - Sessions created with `noReset: true` or without `appPath` will automatically detach on close
+- Sessions attached with `sessionId` always detach on close unless `detach: false` is explicitly requested
 
 ⚠️ **Task Planning:**
 
@@ -1108,6 +1159,8 @@ close_session({detach: false})  // or just close_session()
 ```
 
 Sessions created with `noReset: true` or without `appPath` will automatically detach on close.
+Sessions attached by `sessionId` are externally managed and also detach by default; pass `detach: false` only when the
+MCP should deliberately terminate the existing remote session.
 
 This is particularly useful when:
 

--- a/src/providers/external.provider.ts
+++ b/src/providers/external.provider.ts
@@ -8,6 +8,8 @@ export type ExternalProviderOptions = {
     path?: string;
   };
   browser?: string;
+  platform?: 'browser' | 'ios' | 'android';
+  automationName?: 'XCUITest' | 'UiAutomator2';
   capabilities?: Record<string, unknown>;
 };
 
@@ -26,14 +28,25 @@ export class ExternalProvider implements SessionProvider {
 
   buildCapabilities(options: Record<string, unknown>): Record<string, unknown> {
     const userCapabilities = (options.capabilities as Record<string, unknown> | undefined) ?? {};
+    const platform = options.platform as ExternalProviderOptions['platform'];
+
+    if (platform === 'ios' || platform === 'android') {
+      return {
+        platformName: platform === 'ios' ? 'iOS' : 'Android',
+        'appium:automationName': (options.automationName as string | undefined)
+          ?? (platform === 'ios' ? 'XCUITest' : 'UiAutomator2'),
+        ...userCapabilities,
+      };
+    }
+
     return {
       browserName: (options.browser as string | undefined) ?? 'chrome',
       ...userCapabilities,
     };
   }
 
-  getSessionType(_options: Record<string, unknown>): 'browser' {
-    return 'browser';
+  getSessionType(options: Record<string, unknown>): 'browser' | 'ios' | 'android' {
+    return (options.platform as 'browser' | 'ios' | 'android' | undefined) ?? 'browser';
   }
 
   shouldAutoDetach(_options: Record<string, unknown>): boolean {

--- a/src/recording/code-generator.ts
+++ b/src/recording/code-generator.ts
@@ -24,6 +24,88 @@ function inferExtensionScheme(history: SessionHistory): 'chrome-extension' | 'mo
   return browserName.includes('firefox') ? 'moz-extension' : 'chrome-extension';
 }
 
+function generateAttachSessionStep(params: Record<string, unknown>, history: SessionHistory): string {
+  const provider = (params.provider as string | undefined) ?? 'local';
+  const platform = params.platform as string;
+  const sessionId = (params.sessionId as string | undefined) ?? history.sessionId;
+  const capabilities = indentJson(history.capabilities).replace(
+    /("(?:digitalai:)?accessKey":\s*)"(?:[^"\\]|\\.)*"/g,
+    '$1process.env.DIGITALAI_ACCESS_KEY',
+  );
+
+  const connectionLines: string[] = [];
+  if (provider === 'browserstack') {
+    connectionLines.push(
+      "  protocol: 'https',",
+      `  hostname: '${platform === 'browser' ? 'hub.browserstack.com' : 'hub-cloud.browserstack.com'}',`,
+      '  port: 443,',
+      "  path: '/wd/hub',",
+      '  user: process.env.BROWSERSTACK_USERNAME,',
+      '  key: process.env.BROWSERSTACK_ACCESS_KEY,',
+    );
+  } else if (provider === 'saucelabs') {
+    const region = (params.region as string | undefined) ?? 'eu-central-1';
+    connectionLines.push(
+      "  protocol: 'https',",
+      `  hostname: 'ondemand.${escapeStr(region)}.saucelabs.com',`,
+      '  port: 443,',
+      "  path: '/wd/hub',",
+      '  user: process.env.SAUCE_USERNAME,',
+      '  key: process.env.SAUCE_ACCESS_KEY,',
+    );
+  } else if (provider === 'testmu') {
+    connectionLines.push(
+      "  protocol: 'https',",
+      `  hostname: '${platform === 'browser' ? 'hub.lambdatest.com' : 'mobile-hub.lambdatest.com'}',`,
+      '  port: 443,',
+      "  path: '/wd/hub',",
+      '  user: process.env.TESTMU_USERNAME,',
+      '  key: process.env.TESTMU_ACCESS_KEY,',
+    );
+  } else if (provider === 'testingbot') {
+    connectionLines.push(
+      "  protocol: 'https',",
+      "  hostname: 'hub.testingbot.com',",
+      '  port: 443,',
+      "  path: '/wd/hub',",
+      '  user: process.env.TESTINGBOT_KEY,',
+      '  key: process.env.TESTINGBOT_SECRET,',
+    );
+  } else if (provider === 'digitalai') {
+    connectionLines.push(
+      "  protocol: 'https',",
+      "  hostname: (process.env.DIGITALAI_CLOUD_URL ?? '').replace(/^https?:\\/\\//, '').replace(/\\/wd\\/hub\\/?$/, '').replace(/\\/+$/, ''),",
+      '  port: 443,',
+      "  path: '/wd/hub',",
+    );
+  } else {
+    const rawConfig = provider === 'external'
+      ? (params.webdriverConfig as Record<string, unknown> | undefined)
+      : (params.appiumConfig as Record<string, unknown> | undefined);
+    if (rawConfig) {
+      const config = {
+        protocol: rawConfig.protocol,
+        hostname: rawConfig.hostname ?? rawConfig.host,
+        port: rawConfig.port,
+        path: rawConfig.path,
+      };
+      for (const [key, value] of Object.entries(config)) {
+        if (value !== undefined) connectionLines.push(`  ${key}: ${JSON.stringify(value)},`);
+      }
+    }
+  }
+
+  const indentedCapabilities = capabilities.split('\n').map(line => `  ${line}`).join('\n');
+  return [
+    'const browser = await attach({',
+    ...connectionLines,
+    `  sessionId: '${escapeStr(sessionId)}',`,
+    `  capabilities: ${indentedCapabilities.trimStart()},`,
+    `  requestedCapabilities: ${indentedCapabilities.trimStart()},`,
+    '});',
+  ].join('\n');
+}
+
 function generateStep(step: RecordedStep, history: SessionHistory): string {
   if (step.tool === '__session_transition__') {
     const newId = (step.params.newSessionId as string) ?? 'unknown';
@@ -36,6 +118,8 @@ function generateStep(step: RecordedStep, history: SessionHistory): string {
 
   const p = step.params;
   switch (step.tool) {
+    case 'attach_session':
+      return generateAttachSessionStep(p, history);
     case 'start_session': {
       const platform = p.platform as string;
       const isBrowserStack = 'bstack:options' in history.capabilities;
@@ -241,6 +325,16 @@ export function generateCode(history: SessionHistory): string {
     .split('\n')
     .map(line => `  ${line}`)
     .join('\n');
+
+  if (history.steps.some(step => step.tool === 'attach_session')) {
+    return [
+      "import { attach } from 'webdriverio';",
+      '',
+      steps.replace(/^ {2}/gm, ''),
+      '',
+      '// The externally managed session is intentionally left running.',
+    ].join('\n');
+  }
 
   if (isBrowserStack) {
     const bsSteps = steps.replace(/const browser = await remote\(/g, 'browser = await remote(');

--- a/src/server.ts
+++ b/src/server.ts
@@ -65,6 +65,8 @@ import {
   tabsResource,
 } from './resources';
 import {
+  attachSessionTool,
+  attachSessionToolDefinition,
   closeSessionTool,
   closeSessionToolDefinition,
   startSessionTool,
@@ -130,6 +132,7 @@ function createServer(): McpServer {
     withTrace(name, withRecording(name, cb));
 
   registerTool(startSessionToolDefinition, withRecording('start_session', startSessionTool));
+  registerTool(attachSessionToolDefinition, withRecording('attach_session', attachSessionTool));
   registerTool(closeSessionToolDefinition, closeSessionTool);
   registerTool(launchChromeToolDefinition, instrument('launch_chrome', launchChromeTool));
   registerTool(emulateDeviceToolDefinition, emulateDeviceTool);

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -81,18 +81,18 @@ export function registerSession(
         if (oldMetadata?.trace) {
           await finalizeTrace(oldSessionId, oldBrowser);
         }
-        if (oldMetadata?.provider) {
+        if (oldMetadata?.provider && !oldMetadata.externallyManaged) {
           const oldHistory = state.sessionHistory.get(oldSessionId);
           const provider = getProvider(oldMetadata.provider, oldMetadata.type);
           await provider.onSessionClose?.(oldSessionId, oldMetadata.type, getSessionResult(oldHistory), oldMetadata.tunnelHandle, oldBrowser, oldMetadata.region).catch(() => {
           });
         }
-        if (!oldMetadata?.isAttached) {
+        if (!oldMetadata?.isAttached && !oldMetadata?.externallyManaged) {
           await oldBrowser.deleteSession().catch(() => {
             // Ignore errors during force-close of orphaned session
           });
         }
-        if (oldMetadata?.provider && oldMetadata?.tunnelHandle) {
+        if (oldMetadata?.provider && oldMetadata?.tunnelHandle && !oldMetadata.externallyManaged) {
           const provider = getProvider(oldMetadata.provider, oldMetadata.type);
           await provider.stopTunnel?.(oldMetadata.tunnelHandle).catch(() => {});
         }

--- a/src/session/state.ts
+++ b/src/session/state.ts
@@ -9,6 +9,8 @@ export interface SessionMetadata {
   tunnelName?: string;
   tunnelHandle?: unknown;
   trace?: boolean;
+  /** The remote session lifecycle is owned outside this MCP process. */
+  externallyManaged?: boolean;
 }
 
 const state = {

--- a/src/tools/session.tool.ts
+++ b/src/tools/session.tool.ts
@@ -1,4 +1,4 @@
-import { remote } from 'webdriverio';
+import { attach, remote } from 'webdriverio';
 import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolDefinition } from '../types/tool';
@@ -16,7 +16,7 @@ const automationEnum = z.enum(['XCUITest', 'UiAutomator2']);
 
 export const startSessionToolDefinition: ToolDefinition = {
   name: 'start_session',
-  description: 'Starts a browser or mobile automation session. Only one active session at a time — starting a new one closes the existing session first. Use platform "browser" with a browser name, or "ios"/"android" with deviceName. Set attach: true to connect to a running Chrome via CDP instead of launching a new browser.',
+  description: 'Starts or attaches to a browser or mobile automation session. Only one active session at a time — starting or attaching to another session closes or detaches from the existing session first. Use sessionId to attach to an existing remote WebDriver/Appium session, or attach: true to connect to a running Chrome via CDP.',
   annotations: { title: 'Start Session', destructiveHint: false },
   inputSchema: {
     provider: z.enum(['local', 'browserstack', 'saucelabs', 'testmu', 'testingbot', 'digitalai', 'external']).optional().default('local').describe('Session provider (default: local). Use "external" to connect to an externally managed W3C WebDriver endpoint. "digitalai" requires DIGITALAI_CLOUD_URL + DIGITALAI_ACCESS_KEY env vars.'),
@@ -48,6 +48,7 @@ export const startSessionToolDefinition: ToolDefinition = {
     fullReset: coerceBoolean.optional().describe('Uninstall app before/after session'),
     newCommandTimeout: z.number().min(0).optional().default(300).describe('Appium command timeout in seconds'),
     trace: coerceBoolean.optional().default(false).describe('Enable trace recording — produces a Playwright-compatible zip saved to .trace/ on close_session, playable at player.vibium.dev.'),
+    sessionId: z.string().min(1).optional().describe('Existing remote WebDriver/Appium session ID to attach to instead of creating a new session. The session is detached, not terminated, by default on close.'),
     attach: coerceBoolean.optional().default(false).describe('Attach to existing Chrome instead of launching'),
     attachConfig: z.object({
       port: z.number().optional().default(9222),
@@ -102,6 +103,7 @@ type StartSessionArgs = {
   fullReset?: boolean;
   newCommandTimeout?: number;
   trace?: boolean;
+  sessionId?: string;
   attach?: boolean;
   attachConfig?: { port?: number; host?: string };
   webdriverConfig?: { protocol?: string; hostname?: string; port?: number; path?: string };
@@ -370,6 +372,88 @@ async function startMobileSession(args: StartSessionArgs): Promise<CallToolResul
   };
 }
 
+async function attachExistingSession(args: StartSessionArgs): Promise<CallToolResult> {
+  const { sessionId, platform, navigationUrl } = args;
+  if (!sessionId) throw new Error('sessionId is required to attach to an existing session');
+
+  const providerName = args.provider ?? 'local';
+  const provider = getProvider(providerName, platform);
+  const connectionConfig = provider.getConnectionConfig(args as Record<string, unknown>);
+  const mergedCapabilities = provider.buildCapabilities(args as Record<string, unknown>);
+
+  // Capabilities are not sent to the server while attaching, but WebdriverIO uses them
+  // to register the correct platform-specific command surface on the local client.
+  if (platform === 'ios' || platform === 'android') {
+    mergedCapabilities.platformName = platform === 'ios' ? 'iOS' : 'Android';
+    mergedCapabilities['appium:automationName'] = args.automationName
+      ?? (platform === 'ios' ? 'XCUITest' : 'UiAutomator2');
+  }
+
+  const browser = await attach({
+    ...connectionConfig,
+    sessionId,
+    capabilities: mergedCapabilities,
+    requestedCapabilities: mergedCapabilities,
+  });
+  const sessionType = provider.getSessionType(args as Record<string, unknown>);
+
+  const metadata: SessionMetadata = {
+    type: sessionType,
+    capabilities: mergedCapabilities,
+    isAttached: true,
+    externallyManaged: true,
+    provider: providerName,
+    region: args.region,
+    trace: args.trace ?? false,
+  };
+
+  registerSession(sessionId, browser, metadata, {
+    sessionId,
+    type: sessionType,
+    startedAt: new Date().toISOString(),
+    capabilities: mergedCapabilities,
+    ...(platform === 'browser' ? {} : {
+      appiumConfig: {
+        hostname: connectionConfig.hostname,
+        port: connectionConfig.port,
+        path: connectionConfig.path,
+      },
+    }),
+    steps: [],
+  });
+
+  if (args.trace) {
+    const viewport = platform === 'browser'
+      ? { width: args.windowWidth ?? 1920, height: args.windowHeight ?? 1080 }
+      : undefined;
+    startTrace(sessionId, mergedCapabilities, sessionType, viewport);
+  }
+
+  if (platform === 'browser' && navigationUrl) {
+    await browser.url(navigationUrl);
+    if (args.trace) await recordInitialNavigation(sessionId, navigationUrl);
+  }
+
+  const protocol = connectionConfig.protocol ?? 'http';
+  const hostname = connectionConfig.hostname ?? '127.0.0.1';
+  const port = connectionConfig.port ?? (protocol === 'https' ? 443 : 4444);
+  const path = connectionConfig.path ?? '/';
+  const reportNote = provider.getStartNote?.(browser) ?? '';
+
+  return {
+    content: [{
+      type: 'text',
+      text: [
+        `Attached to existing ${platform} session with sessionId: ${sessionId}`,
+        `Provider: ${providerName}`,
+        `Endpoint: ${protocol}://${hostname}:${port}${path}`,
+        'The externally managed session will be detached by default on close.',
+        reportNote.trim(),
+      ].filter(Boolean).join('\n'),
+    }],
+  };
+}
+
 async function attachBrowserSession(args: StartSessionArgs): Promise<CallToolResult> {
   const { port = 9222, host = 'localhost' } = args.attachConfig ?? {};
   const { navigationUrl } = args;
@@ -439,6 +523,28 @@ async function attachBrowserSession(args: StartSessionArgs): Promise<CallToolRes
 
 export const startSessionTool: ToolCallback = async (args: StartSessionArgs): Promise<CallToolResult> => {
   try {
+    if (args.sessionId && args.attach) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: 'Error starting session: sessionId cannot be combined with attach: true. Use sessionId for WebDriver/Appium attachment or attach for Chrome CDP attachment.' }],
+      };
+    }
+
+    const managedTunnel = args.tunnel === true
+      || args.browserstackLocal === true
+      || args.saucelabsLocal === true
+      || args.testmuLocal === true;
+    if (args.sessionId && managedTunnel) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: 'Error starting session: an existing session cannot start an MCP-managed tunnel. Keep the original tunnel running and use tunnel: "external" when applicable.' }],
+      };
+    }
+
+    if (args.sessionId) {
+      return await attachExistingSession(args);
+    }
+
     if (args.provider === 'external' && args.platform !== 'browser') {
       return {
         isError: true,
@@ -466,7 +572,8 @@ export const closeSessionTool: ToolCallback = async (args: { detach?: boolean } 
     const metadata = state.sessionMetadata.get(sessionId);
 
     const isAttached = !!metadata?.isAttached;
-    const detach = args.detach ?? metadata?.provider === 'external';
+    const detachByDefault = metadata?.externallyManaged === true || metadata?.provider === 'external';
+    const detach = args.detach ?? detachByDefault;
 
     // Determine if this is a force-close (auto-detached session + explicit close)
     const force = !detach && isAttached;

--- a/src/tools/session.tool.ts
+++ b/src/tools/session.tool.ts
@@ -16,7 +16,7 @@ const automationEnum = z.enum(['XCUITest', 'UiAutomator2']);
 
 export const startSessionToolDefinition: ToolDefinition = {
   name: 'start_session',
-  description: 'Starts or attaches to a browser or mobile automation session. Only one active session at a time — starting or attaching to another session closes or detaches from the existing session first. Use sessionId to attach to an existing remote WebDriver/Appium session, or attach: true to connect to a running Chrome via CDP.',
+  description: 'Starts a new browser or mobile automation session. Only one active session at a time — starting another session closes or detaches from the existing session first. Use attach: true to connect to a running Chrome via CDP.',
   annotations: { title: 'Start Session', destructiveHint: false },
   inputSchema: {
     provider: z.enum(['local', 'browserstack', 'saucelabs', 'testmu', 'testingbot', 'digitalai', 'external']).optional().default('local').describe('Session provider (default: local). Use "external" to connect to an externally managed W3C WebDriver endpoint. "digitalai" requires DIGITALAI_CLOUD_URL + DIGITALAI_ACCESS_KEY env vars.'),
@@ -48,7 +48,6 @@ export const startSessionToolDefinition: ToolDefinition = {
     fullReset: coerceBoolean.optional().describe('Uninstall app before/after session'),
     newCommandTimeout: z.number().min(0).optional().default(300).describe('Appium command timeout in seconds'),
     trace: coerceBoolean.optional().default(false).describe('Enable trace recording — produces a Playwright-compatible zip saved to .trace/ on close_session, playable at player.vibium.dev.'),
-    sessionId: z.string().min(1).optional().describe('Existing remote WebDriver/Appium session ID to attach to instead of creating a new session. The session is detached, not terminated, by default on close.'),
     attach: coerceBoolean.optional().default(false).describe('Attach to existing Chrome instead of launching'),
     attachConfig: z.object({
       port: z.number().optional().default(9222),
@@ -74,6 +73,34 @@ export const startSessionToolDefinition: ToolDefinition = {
     testmuLocal: z.union([z.literal('external'), coerceBoolean]).optional().describe('Deprecated: use "tunnel" instead. Enable TestMu Tunnel routing.'),
     navigationUrl: z.string().optional().describe('URL to navigate to after starting'),
     capabilities: z.record(z.string(), z.unknown()).optional().describe('Additional capabilities to merge'),
+  },
+};
+
+export const attachSessionToolDefinition: ToolDefinition = {
+  name: 'attach_session',
+  description: 'Attaches to an existing remote WebDriver or Appium session by ID without creating a new session. Only one session can be active at a time. The externally managed session is detached, not terminated, by default on close.',
+  annotations: { title: 'Attach Session', destructiveHint: false },
+  inputSchema: {
+    sessionId: z.string().min(1).describe('Existing remote WebDriver/Appium session ID'),
+    provider: z.enum(['local', 'browserstack', 'saucelabs', 'testmu', 'testingbot', 'digitalai', 'external']).optional().default('local').describe('Provider hosting the existing session (default: local). Use "external" for a custom W3C WebDriver endpoint.'),
+    platform: platformEnum.describe('Existing session platform type'),
+    browser: browserEnum.optional().describe('Browser for local command registration (browser platform only, default: chrome)'),
+    automationName: automationEnum.optional().describe('Appium automation driver for local command registration (mobile platforms only)'),
+    webdriverConfig: z.object({
+      protocol: z.string().optional().default('http'),
+      hostname: z.string().optional().default('127.0.0.1'),
+      port: z.number().optional().default(4445),
+      path: z.string().optional().default('/'),
+    }).optional().describe('Existing W3C WebDriver endpoint connection (provider: "external" only). Defaults to 127.0.0.1:4445/.'),
+    appiumConfig: z.object({
+      host: z.string().optional(),
+      port: z.number().optional(),
+      path: z.string().optional(),
+      protocol: z.string().optional(),
+    }).optional().describe('Appium server connection (local provider only)'),
+    region: z.enum(['us-west-1', 'eu-central-1', 'apac-southeast-1']).optional().default('eu-central-1').describe('Sauce Labs region (default: eu-central-1). Only used with provider: "saucelabs".'),
+    trace: coerceBoolean.optional().default(false).describe('Enable trace recording for subsequent commands — produces a Playwright-compatible zip saved to .trace/ on close_session.'),
+    capabilities: z.record(z.string(), z.unknown()).optional().describe('Capabilities used to register the correct browser or Appium command surface locally; they are not sent to the remote endpoint'),
   },
 };
 
@@ -103,7 +130,6 @@ type StartSessionArgs = {
   fullReset?: boolean;
   newCommandTimeout?: number;
   trace?: boolean;
-  sessionId?: string;
   attach?: boolean;
   attachConfig?: { port?: number; host?: string };
   webdriverConfig?: { protocol?: string; hostname?: string; port?: number; path?: string };
@@ -118,12 +144,25 @@ type StartSessionArgs = {
   capabilities?: Record<string, unknown>;
 };
 
+type AttachSessionArgs = {
+  sessionId: string;
+  provider?: 'local' | 'browserstack' | 'saucelabs' | 'testmu' | 'testingbot' | 'digitalai' | 'external';
+  platform: 'browser' | 'ios' | 'android';
+  browser?: 'chrome' | 'firefox' | 'edge' | 'safari';
+  automationName?: 'XCUITest' | 'UiAutomator2';
+  webdriverConfig?: { protocol?: string; hostname?: string; port?: number; path?: string };
+  appiumConfig?: { host?: string; port?: number; path?: string; protocol?: string };
+  region?: 'us-west-1' | 'eu-central-1' | 'apac-southeast-1';
+  trace?: boolean;
+  capabilities?: Record<string, unknown>;
+};
+
 export const closeSessionToolDefinition: ToolDefinition = {
   name: 'close_session',
   description: 'Closes the current session or detaches without terminating. Detach preserves app state on the Appium server — sessions with noReset: true auto-detach by default. Closing a browser attach session terminates chromedriver but the Chrome process spawned by launch_chrome remains running.',
   annotations: { title: 'Close Session', destructiveHint: true },
   inputSchema: {
-    detach: coerceBoolean.optional().describe('If true, disconnect without terminating (preserves app state). Default: false'),
+    detach: coerceBoolean.optional().describe('If true, disconnect without terminating; if false, terminate. When omitted, externally managed and auto-detach sessions are preserved while other sessions are terminated.'),
   },
 };
 
@@ -372,9 +411,8 @@ async function startMobileSession(args: StartSessionArgs): Promise<CallToolResul
   };
 }
 
-async function attachExistingSession(args: StartSessionArgs): Promise<CallToolResult> {
-  const { sessionId, platform, navigationUrl } = args;
-  if (!sessionId) throw new Error('sessionId is required to attach to an existing session');
+async function attachExistingSession(args: AttachSessionArgs): Promise<CallToolResult> {
+  const { sessionId, platform } = args;
 
   const providerName = args.provider ?? 'local';
   const provider = getProvider(providerName, platform);
@@ -424,14 +462,9 @@ async function attachExistingSession(args: StartSessionArgs): Promise<CallToolRe
 
   if (args.trace) {
     const viewport = platform === 'browser'
-      ? { width: args.windowWidth ?? 1920, height: args.windowHeight ?? 1080 }
+      ? { width: 1920, height: 1080 }
       : undefined;
     startTrace(sessionId, mergedCapabilities, sessionType, viewport);
-  }
-
-  if (platform === 'browser' && navigationUrl) {
-    await browser.url(navigationUrl);
-    if (args.trace) await recordInitialNavigation(sessionId, navigationUrl);
   }
 
   const protocol = connectionConfig.protocol ?? 'http';
@@ -523,28 +556,6 @@ async function attachBrowserSession(args: StartSessionArgs): Promise<CallToolRes
 
 export const startSessionTool: ToolCallback = async (args: StartSessionArgs): Promise<CallToolResult> => {
   try {
-    if (args.sessionId && args.attach) {
-      return {
-        isError: true,
-        content: [{ type: 'text', text: 'Error starting session: sessionId cannot be combined with attach: true. Use sessionId for WebDriver/Appium attachment or attach for Chrome CDP attachment.' }],
-      };
-    }
-
-    const managedTunnel = args.tunnel === true
-      || args.browserstackLocal === true
-      || args.saucelabsLocal === true
-      || args.testmuLocal === true;
-    if (args.sessionId && managedTunnel) {
-      return {
-        isError: true,
-        content: [{ type: 'text', text: 'Error starting session: an existing session cannot start an MCP-managed tunnel. Keep the original tunnel running and use tunnel: "external" when applicable.' }],
-      };
-    }
-
-    if (args.sessionId) {
-      return await attachExistingSession(args);
-    }
-
     if (args.provider === 'external' && args.platform !== 'browser') {
       return {
         isError: true,
@@ -561,6 +572,14 @@ export const startSessionTool: ToolCallback = async (args: StartSessionArgs): Pr
     return await startMobileSession(args);
   } catch (e) {
     return { isError: true, content: [{ type: 'text', text: `Error starting session: ${e}` }] };
+  }
+};
+
+export const attachSessionTool: ToolCallback = async (args: AttachSessionArgs): Promise<CallToolResult> => {
+  try {
+    return await attachExistingSession(args);
+  } catch (e) {
+    return { isError: true, content: [{ type: 'text', text: `Error attaching to session: ${e}` }] };
   }
 };
 

--- a/tests/providers/external.provider.test.ts
+++ b/tests/providers/external.provider.test.ts
@@ -42,6 +42,26 @@ describe('ExternalProvider', () => {
     });
   });
 
+  it('builds platform capabilities for an attached iOS session', () => {
+    expect(provider.buildCapabilities({ platform: 'ios' })).toEqual({
+      platformName: 'iOS',
+      'appium:automationName': 'XCUITest',
+    });
+    expect(provider.getSessionType({ platform: 'ios' })).toBe('ios');
+  });
+
+  it('builds platform capabilities for an attached Android session', () => {
+    expect(provider.buildCapabilities({
+      platform: 'android',
+      capabilities: { 'appium:deviceName': 'Pixel 9' },
+    })).toEqual({
+      platformName: 'Android',
+      'appium:automationName': 'UiAutomator2',
+      'appium:deviceName': 'Pixel 9',
+    });
+    expect(provider.getSessionType({ platform: 'android' })).toBe('android');
+  });
+
   it('reports browser session semantics', () => {
     expect(provider.getSessionType({})).toBe('browser');
     expect(provider.shouldAutoDetach({})).toBe(true);

--- a/tests/recording/code-generator.test.ts
+++ b/tests/recording/code-generator.test.ts
@@ -174,6 +174,34 @@ describe('generateCode - header', () => {
     expect(code).toContain('"port": 4723');
     expect(code).toContain('"platformName": "Android"');
   });
+
+  it('generates attach_session with attach() and preserves the external session', () => {
+    const history: SessionHistory = {
+      sessionId: 'existing-bs-session',
+      type: 'ios',
+      startedAt: '2026-01-01T00:00:00.000Z',
+      capabilities: {
+        platformName: 'iOS',
+        'appium:automationName': 'XCUITest',
+      },
+      steps: [{
+        index: 1,
+        tool: 'attach_session',
+        params: { sessionId: 'existing-bs-session', provider: 'browserstack', platform: 'ios' },
+        status: 'ok',
+        durationMs: 100,
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }],
+    };
+
+    const code = generateCode(history);
+    expect(code).toContain("import { attach } from 'webdriverio';");
+    expect(code).toContain('const browser = await attach({');
+    expect(code).toContain("hostname: 'hub-cloud.browserstack.com'");
+    expect(code).toContain("sessionId: 'existing-bs-session'");
+    expect(code).not.toContain('remote(');
+    expect(code).not.toContain('deleteSession');
+  });
 });
 
 describe('generateCode - tool mappings', () => {

--- a/tests/session/lifecycle.test.ts
+++ b/tests/session/lifecycle.test.ts
@@ -104,6 +104,48 @@ describe('registerSession', () => {
     expect(oldBrowser.deleteSession).not.toHaveBeenCalled();
   });
 
+  it('does not report, delete, or stop resources for an externally managed previous session', async () => {
+    const state = getState();
+    const tunnel = makeTunnel();
+    const oldBrowser = makeBrowser();
+    const oldMeta: SessionMetadata = {
+      type: 'ios',
+      capabilities: {},
+      isAttached: true,
+      externallyManaged: true,
+      provider: 'browserstack',
+      tunnelHandle: tunnel,
+    };
+    state.browsers.set('external-session', oldBrowser);
+    state.sessionMetadata.set('external-session', oldMeta);
+    state.sessionHistory.set('external-session', {
+      sessionId: 'external-session',
+      type: 'ios',
+      startedAt: new Date().toISOString(),
+      capabilities: {},
+      steps: [],
+    });
+    state.currentSession = 'external-session';
+
+    registerSession('new-session', makeBrowser(), {
+      type: 'browser',
+      capabilities: {},
+      isAttached: false,
+    }, {
+      sessionId: 'new-session',
+      type: 'browser',
+      startedAt: new Date().toISOString(),
+      capabilities: {},
+      steps: [],
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(mockOnSessionClose).not.toHaveBeenCalled();
+    expect(oldBrowser.deleteSession).not.toHaveBeenCalled();
+    expect(tunnel.stop).not.toHaveBeenCalled();
+  });
+
   it('appends session_transition to previous session', () => {
     const state = getState();
     const meta: SessionMetadata = { type: 'browser', capabilities: {}, isAttached: false };

--- a/tests/tools/attach-existing-session.integration.test.ts
+++ b/tests/tools/attach-existing-session.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { getContextsTool } from '../../src/tools/get-contexts.tool';
-import { closeSessionTool, startSessionTool } from '../../src/tools/session.tool';
+import { attachSessionTool, closeSessionTool } from '../../src/tools/session.tool';
 import { switchContextTool } from '../../src/tools/context.tool';
 import { getState } from '../../src/session/state';
 
@@ -10,7 +10,7 @@ type ToolFn = (args: Record<string, unknown>) => Promise<{
   isError?: boolean;
 }>;
 
-const callStart = startSessionTool as unknown as ToolFn;
+const callAttach = attachSessionTool as unknown as ToolFn;
 const callContexts = getContextsTool as unknown as ToolFn;
 const callSwitch = switchContextTool as unknown as ToolFn;
 const callClose = closeSessionTool as unknown as ToolFn;
@@ -62,7 +62,7 @@ describe('existing session protocol integration', () => {
   });
 
   it('drives an existing Appium session without creating or deleting it', async () => {
-    const startResult = await callStart({
+    const startResult = await callAttach({
       sessionId: 'existing-appium-session',
       provider: 'external',
       platform: 'ios',

--- a/tests/tools/attach-existing-session.integration.test.ts
+++ b/tests/tools/attach-existing-session.integration.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { getContextsTool } from '../../src/tools/get-contexts.tool';
+import { closeSessionTool, startSessionTool } from '../../src/tools/session.tool';
+import { switchContextTool } from '../../src/tools/context.tool';
+import { getState } from '../../src/session/state';
+
+type ToolFn = (args: Record<string, unknown>) => Promise<{
+  content: { text: string }[];
+  isError?: boolean;
+}>;
+
+const callStart = startSessionTool as unknown as ToolFn;
+const callContexts = getContextsTool as unknown as ToolFn;
+const callSwitch = switchContextTool as unknown as ToolFn;
+const callClose = closeSessionTool as unknown as ToolFn;
+
+describe('existing session protocol integration', () => {
+  let server: Server;
+  let port: number;
+  let requests: { method: string; url: string }[];
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      requests.push({ method: req.method ?? '', url: req.url ?? '' });
+      res.setHeader('Content-Type', 'application/json');
+
+      if (req.method === 'GET' && req.url?.endsWith('/contexts')) {
+        res.end(JSON.stringify({ value: ['NATIVE_APP', 'WEBVIEW_1'] }));
+        return;
+      }
+      if (req.method === 'GET' && req.url?.endsWith('/context')) {
+        res.end(JSON.stringify({ value: 'NATIVE_APP' }));
+        return;
+      }
+      if (req.method === 'POST' && req.url?.endsWith('/context')) {
+        res.end(JSON.stringify({ value: null }));
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end(JSON.stringify({ value: { error: 'unknown command' } }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Failed to bind test WebDriver server');
+    port = address.port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+  });
+
+  beforeEach(() => {
+    requests = [];
+    const state = getState();
+    state.browsers.clear();
+    state.sessionMetadata.clear();
+    state.sessionHistory.clear();
+    state.currentSession = null;
+  });
+
+  it('drives an existing Appium session without creating or deleting it', async () => {
+    const startResult = await callStart({
+      sessionId: 'existing-appium-session',
+      provider: 'external',
+      platform: 'ios',
+      webdriverConfig: {
+        protocol: 'http',
+        hostname: '127.0.0.1',
+        port,
+        path: '/',
+      },
+    });
+
+    expect(startResult.isError).toBeUndefined();
+    expect(requests).toEqual([]);
+
+    const contextsResult = await callContexts({});
+    expect(contextsResult.isError).toBeUndefined();
+    expect(JSON.parse(contextsResult.content[0].text)).toEqual({
+      contexts: ['NATIVE_APP', 'WEBVIEW_1'],
+      currentContext: 'NATIVE_APP',
+    });
+
+    const switchResult = await callSwitch({ context: 'WEBVIEW_1' });
+    expect(switchResult.isError).toBeUndefined();
+    expect(requests).toContainEqual({
+      method: 'POST',
+      url: '/session/existing-appium-session/context',
+    });
+    expect(requests.some(request => request.method === 'POST' && request.url === '/session')).toBe(false);
+
+    const closeResult = await callClose({});
+    expect(closeResult.content[0].text).toContain('detached from');
+    expect(requests.some(request => request.method === 'DELETE')).toBe(false);
+  });
+});

--- a/tests/tools/attach-existing-session.test.ts
+++ b/tests/tools/attach-existing-session.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { attach, remote } from 'webdriverio';
+import { Local as BrowserstackTunnel } from 'browserstack-local';
+import { registerSession } from '../../src/session/lifecycle';
+import { startSessionTool, startSessionToolDefinition } from '../../src/tools/session.tool';
+
+const mockBrowser = vi.hoisted(() => ({
+  sessionId: 'existing-session-id',
+  capabilities: {},
+  url: vi.fn(),
+}));
+
+vi.mock('webdriverio', () => ({
+  attach: vi.fn().mockResolvedValue(mockBrowser),
+  remote: vi.fn(),
+}));
+
+vi.mock('browserstack-local', () => ({
+  Local: vi.fn(),
+}));
+
+vi.mock('../../src/session/lifecycle', () => ({
+  registerSession: vi.fn(),
+}));
+
+vi.mock('../../src/session/state', () => ({
+  getState: vi.fn(() => ({
+    browsers: new Map(),
+    currentSession: null,
+    sessionMetadata: new Map(),
+    sessionHistory: new Map(),
+  })),
+}));
+
+type ToolFn = (args: Record<string, unknown>) => Promise<{ content: { text: string }[]; isError?: boolean }>;
+const callTool = startSessionTool as unknown as ToolFn;
+const mockAttach = attach as ReturnType<typeof vi.fn>;
+const mockRemote = remote as ReturnType<typeof vi.fn>;
+const mockRegisterSession = registerSession as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('BROWSERSTACK_USERNAME', 'testuser');
+  vi.stubEnv('BROWSERSTACK_ACCESS_KEY', 'testkey');
+  mockAttach.mockResolvedValue(mockBrowser);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('start_session with sessionId', () => {
+  it('exposes sessionId in the tool schema', () => {
+    const schema = startSessionToolDefinition.inputSchema.sessionId as unknown as {
+      safeParse: (value: unknown) => { success: boolean };
+    };
+
+    expect(schema.safeParse('abc123').success).toBe(true);
+    expect(schema.safeParse('').success).toBe(false);
+  });
+
+  it('attaches to an existing BrowserStack iOS session without creating a session', async () => {
+    const result = await callTool({
+      sessionId: 'existing-session-id',
+      provider: 'browserstack',
+      platform: 'ios',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockAttach).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'existing-session-id',
+      protocol: 'https',
+      hostname: 'hub-cloud.browserstack.com',
+      port: 443,
+      path: '/wd/hub',
+      user: 'testuser',
+      key: 'testkey',
+      capabilities: expect.objectContaining({
+        platformName: 'iOS',
+        'appium:automationName': 'XCUITest',
+      }),
+    }));
+    expect(mockRemote).not.toHaveBeenCalled();
+    expect(BrowserstackTunnel).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('Attached to existing ios session');
+  });
+
+  it('attaches to a local Appium endpoint without requiring an app or noReset', async () => {
+    await callTool({
+      sessionId: 'existing-session-id',
+      provider: 'local',
+      platform: 'android',
+      appiumConfig: {
+        protocol: 'http',
+        host: 'appium.internal',
+        port: 4725,
+        path: '/wd/hub',
+      },
+    });
+
+    expect(mockAttach).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'existing-session-id',
+      protocol: 'http',
+      hostname: 'appium.internal',
+      port: 4725,
+      path: '/wd/hub',
+      capabilities: expect.objectContaining({
+        platformName: 'Android',
+        'appium:automationName': 'UiAutomator2',
+      }),
+    }));
+  });
+
+  it('supports externally managed mobile WebDriver endpoints', async () => {
+    await callTool({
+      sessionId: 'existing-session-id',
+      provider: 'external',
+      platform: 'ios',
+      webdriverConfig: {
+        protocol: 'https',
+        hostname: 'grid.example.com',
+        port: 443,
+        path: '/wd/hub',
+      },
+      capabilities: {
+        'appium:deviceName': 'iPhone 15',
+      },
+    });
+
+    expect(mockAttach).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'existing-session-id',
+      hostname: 'grid.example.com',
+      capabilities: expect.objectContaining({
+        platformName: 'iOS',
+        'appium:automationName': 'XCUITest',
+        'appium:deviceName': 'iPhone 15',
+      }),
+    }));
+  });
+
+  it('registers the attached session as externally managed', async () => {
+    await callTool({
+      sessionId: 'existing-session-id',
+      provider: 'browserstack',
+      platform: 'ios',
+    });
+
+    expect(mockRegisterSession).toHaveBeenCalledWith(
+      'existing-session-id',
+      mockBrowser,
+      expect.objectContaining({
+        type: 'ios',
+        provider: 'browserstack',
+        isAttached: true,
+        externallyManaged: true,
+      }),
+      expect.objectContaining({
+        sessionId: 'existing-session-id',
+        type: 'ios',
+      }),
+    );
+  });
+
+  it('navigates only when navigationUrl is explicitly supplied for a browser session', async () => {
+    await callTool({
+      sessionId: 'existing-session-id',
+      provider: 'browserstack',
+      platform: 'browser',
+      browser: 'chrome',
+      navigationUrl: 'https://example.com',
+    });
+
+    expect(mockBrowser.url).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('rejects sessionId combined with Chrome CDP attach', async () => {
+    const result = await callTool({
+      sessionId: 'existing-session-id',
+      platform: 'browser',
+      attach: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('cannot be combined');
+    expect(mockAttach).not.toHaveBeenCalled();
+  });
+
+  it('rejects starting a managed tunnel for an already-created session', async () => {
+    const result = await callTool({
+      sessionId: 'existing-session-id',
+      provider: 'browserstack',
+      platform: 'ios',
+      tunnel: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('cannot start an MCP-managed tunnel');
+    expect(mockAttach).not.toHaveBeenCalled();
+  });
+
+  it('returns a tool error when WebdriverIO attachment fails', async () => {
+    mockAttach.mockRejectedValueOnce(new Error('invalid session id'));
+
+    const result = await callTool({
+      sessionId: 'missing-session',
+      provider: 'browserstack',
+      platform: 'ios',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid session id');
+  });
+});

--- a/tests/tools/attach-existing-session.test.ts
+++ b/tests/tools/attach-existing-session.test.ts
@@ -2,12 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { attach, remote } from 'webdriverio';
 import { Local as BrowserstackTunnel } from 'browserstack-local';
 import { registerSession } from '../../src/session/lifecycle';
-import { startSessionTool, startSessionToolDefinition } from '../../src/tools/session.tool';
+import {
+  attachSessionTool,
+  attachSessionToolDefinition,
+  startSessionToolDefinition,
+} from '../../src/tools/session.tool';
 
 const mockBrowser = vi.hoisted(() => ({
   sessionId: 'existing-session-id',
   capabilities: {},
-  url: vi.fn(),
 }));
 
 vi.mock('webdriverio', () => ({
@@ -33,7 +36,7 @@ vi.mock('../../src/session/state', () => ({
 }));
 
 type ToolFn = (args: Record<string, unknown>) => Promise<{ content: { text: string }[]; isError?: boolean }>;
-const callTool = startSessionTool as unknown as ToolFn;
+const callTool = attachSessionTool as unknown as ToolFn;
 const mockAttach = attach as ReturnType<typeof vi.fn>;
 const mockRemote = remote as ReturnType<typeof vi.fn>;
 const mockRegisterSession = registerSession as ReturnType<typeof vi.fn>;
@@ -49,14 +52,18 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe('start_session with sessionId', () => {
-  it('exposes sessionId in the tool schema', () => {
-    const schema = startSessionToolDefinition.inputSchema.sessionId as unknown as {
+describe('attach_session', () => {
+  it('owns session-ID attachment in a dedicated, narrow schema', () => {
+    const schema = attachSessionToolDefinition.inputSchema.sessionId as unknown as {
       safeParse: (value: unknown) => { success: boolean };
     };
 
     expect(schema.safeParse('abc123').success).toBe(true);
     expect(schema.safeParse('').success).toBe(false);
+    expect(startSessionToolDefinition.inputSchema.sessionId).toBeUndefined();
+    expect(attachSessionToolDefinition.inputSchema.attach).toBeUndefined();
+    expect(attachSessionToolDefinition.inputSchema.tunnel).toBeUndefined();
+    expect(attachSessionToolDefinition.inputSchema.navigationUrl).toBeUndefined();
   });
 
   it('attaches to an existing BrowserStack iOS session without creating a session', async () => {
@@ -159,43 +166,6 @@ describe('start_session with sessionId', () => {
         type: 'ios',
       }),
     );
-  });
-
-  it('navigates only when navigationUrl is explicitly supplied for a browser session', async () => {
-    await callTool({
-      sessionId: 'existing-session-id',
-      provider: 'browserstack',
-      platform: 'browser',
-      browser: 'chrome',
-      navigationUrl: 'https://example.com',
-    });
-
-    expect(mockBrowser.url).toHaveBeenCalledWith('https://example.com');
-  });
-
-  it('rejects sessionId combined with Chrome CDP attach', async () => {
-    const result = await callTool({
-      sessionId: 'existing-session-id',
-      platform: 'browser',
-      attach: true,
-    });
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('cannot be combined');
-    expect(mockAttach).not.toHaveBeenCalled();
-  });
-
-  it('rejects starting a managed tunnel for an already-created session', async () => {
-    const result = await callTool({
-      sessionId: 'existing-session-id',
-      provider: 'browserstack',
-      platform: 'ios',
-      tunnel: true,
-    });
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('cannot start an MCP-managed tunnel');
-    expect(mockAttach).not.toHaveBeenCalled();
   });
 
   it('returns a tool error when WebdriverIO attachment fails', async () => {

--- a/tests/tools/close-session.test.ts
+++ b/tests/tools/close-session.test.ts
@@ -28,6 +28,7 @@ function setupSession(sessionId: string, isAttached: boolean, metadata: Partial<
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
   const state = getState();
   state.browsers.clear();
   state.sessionMetadata.clear();
@@ -76,6 +77,28 @@ describe('close_session', () => {
 
   it('force-closes external sessions when detach is explicitly false', async () => {
     setupSession('sess-external', true, { provider: 'external' });
+    const result = await callClose({ detach: false });
+
+    expect(mockDeleteSession).toHaveBeenCalledOnce();
+    expect(result.content[0].text).toContain('closed');
+  });
+
+  it('detaches sessionId attachments by default regardless of provider', async () => {
+    setupSession('sess-existing-cloud', true, {
+      provider: 'browserstack',
+      externallyManaged: true,
+    });
+    const result = await callClose({});
+
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('detached from');
+  });
+
+  it('force-closes sessionId attachments when detach is explicitly false', async () => {
+    setupSession('sess-existing-cloud', true, {
+      provider: 'browserstack',
+      externallyManaged: true,
+    });
     const result = await callClose({ detach: false });
 
     expect(mockDeleteSession).toHaveBeenCalledOnce();


### PR DESCRIPTION
Resolves #129

## Proposed changes

Add a dedicated `attach_session` MCP tool for adopting an existing remote WebDriver or Appium session by ID using WebdriverIO's native `attach()` API.

`attach_session` reuses the selected provider's endpoint and credentials and registers the appropriate browser or Appium command surface locally. BrowserStack, Sauce Labs, TestMu, TestingBot, Digital.ai, local Appium, and custom W3C WebDriver endpoints are supported.

Attached sessions are treated as externally managed:

- `close_session()` detaches locally and leaves the remote session running.
- `close_session({ detach: false })` explicitly terminates the remote session.
- Switching to another MCP session does not terminate the attached session.
- MCP does not start or stop a tunnel owned by the process that created the session.

The existing `start_session({ attach: true })` Chrome CDP behavior remains unchanged. Recorded session code now uses `attach()` and preserves the externally managed session as well.

### Validation

- Full test suite: 490 tests passing.
- Added a protocol-level integration test using a local HTTP WebDriver endpoint. It verifies that attachment sends no `POST /session`, subsequent Appium commands target the supplied session ID, and default close sends no `DELETE`.
- Validated against a real BrowserStack iOS session created out of band: attached by ID, retrieved and switched Appium contexts, detached and confirmed the session remained alive, reattached, and explicitly terminated it with `detach: false`.
- Type-check and lint complete with no errors.
- Package bundle succeeds.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have squashed commits that belong together
- [x] I have tested with Claude Desktop (or another MCP-compatible client)
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added the necessary documentation for new/changed tools (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

### Reviewers: @webdriverio/project-committers
