### PR TITLE
fix(saucelabs): preserve user sauce:options and omit empty tunnelName

### DIFF
--- a/src/providers/cloud/saucelabs.provider.ts
+++ b/src/providers/cloud/saucelabs.provider.ts
@@ -34,13 +34,14 @@ export class SauceLabsProvider implements SessionProvider {
     const saucelabsLocal = (options.tunnel ?? options.saucelabsLocal) as boolean | string | undefined;
     const reporting = options.reporting as { project?: string; build?: string; session?: string } | undefined;
 
-    const sauceOptions: Record<string, unknown> = { region };
+    const userSauceOptions = (userCapabilities['sauce:options'] as Record<string, unknown> | undefined) ?? {};
+    const sauceOptions: Record<string, unknown> = { ...userSauceOptions, region };
 
     if (reporting?.build) sauceOptions.build = reporting.build;
     if (reporting?.session) sauceOptions.name = reporting.session;
     else if (reporting?.project) sauceOptions.name = reporting.project;
 
-    if (saucelabsLocal) {
+    if (saucelabsLocal && options.tunnelName) {
       sauceOptions.tunnelName = options.tunnelName;
     }
 

--- a/tests/providers/saucelabs.provider.test.ts
+++ b/tests/providers/saucelabs.provider.test.ts
@@ -170,18 +170,6 @@ describe('SauceLabsProvider', () => {
       expect(sauce.region).toBe('us-west-1');
     });
 
-    it('merges user sauce:options for mobile native app mode', () => {
-      const caps = provider.buildCapabilities({
-        platform: 'android',
-        deviceName: 'Pixel 7',
-        app: 'storage:filename=app.apk',
-        capabilities: { 'sauce:options': { extendedDebugging: true } },
-      });
-      const sauce = caps['sauce:options'] as Record<string, unknown>;
-      expect(sauce.extendedDebugging).toBe(true);
-      expect(sauce.appiumVersion).toBe('latest');
-    });
-
     it('merges user capabilities at top level', () => {
       const caps = provider.buildCapabilities({
         platform: 'browser',
@@ -271,6 +259,18 @@ describe('SauceLabsProvider', () => {
         app: 'storage:filename=app.apk',
       });
       expect(caps['appium:automationName']).toBe('UiAutomator2');
+    });
+
+    it('merges user sauce:options for mobile native app mode', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'android',
+        deviceName: 'Pixel 7',
+        app: 'storage:filename=app.apk',
+        capabilities: { 'sauce:options': { extendedDebugging: true } },
+      });
+      const sauce = caps['sauce:options'] as Record<string, unknown>;
+      expect(sauce.extendedDebugging).toBe(true);
+      expect(sauce.appiumVersion).toBe('latest');
     });
   });
 

--- a/tests/providers/saucelabs.provider.test.ts
+++ b/tests/providers/saucelabs.provider.test.ts
@@ -127,6 +127,61 @@ describe('SauceLabsProvider', () => {
       expect(sauce.tunnelName).toBe('legacy-tunnel');
     });
 
+    it('does not set tunnelName when tunnel is enabled but no tunnelName is given', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'browser',
+        browser: 'chrome',
+        tunnel: true,
+      });
+      const sauce = caps['sauce:options'] as Record<string, unknown>;
+      expect(sauce).not.toHaveProperty('tunnelName');
+    });
+
+    it('does not set tunnelName when tunnel is disabled', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'browser',
+        browser: 'chrome',
+        tunnelName: 'my-tunnel',
+      });
+      const sauce = caps['sauce:options'] as Record<string, unknown>;
+      expect(sauce).not.toHaveProperty('tunnelName');
+    });
+
+    it('merges user-supplied sauce:options into generated sauce:options', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'browser',
+        browser: 'chrome',
+        capabilities: { 'sauce:options': { screenResolution: '1920x1080', extendedDebugging: true } },
+      });
+      const sauce = caps['sauce:options'] as Record<string, unknown>;
+      expect(sauce.screenResolution).toBe('1920x1080');
+      expect(sauce.extendedDebugging).toBe(true);
+      expect(sauce.region).toBeDefined();
+    });
+
+    it('generated region overrides a user-supplied sauce:options region', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'browser',
+        browser: 'chrome',
+        region: 'us-west-1',
+        capabilities: { 'sauce:options': { region: 'eu-central-1' } },
+      });
+      const sauce = caps['sauce:options'] as Record<string, unknown>;
+      expect(sauce.region).toBe('us-west-1');
+    });
+
+    it('merges user sauce:options for mobile native app mode', () => {
+      const caps = provider.buildCapabilities({
+        platform: 'android',
+        deviceName: 'Pixel 7',
+        app: 'storage:filename=app.apk',
+        capabilities: { 'sauce:options': { extendedDebugging: true } },
+      });
+      const sauce = caps['sauce:options'] as Record<string, unknown>;
+      expect(sauce.extendedDebugging).toBe(true);
+      expect(sauce.appiumVersion).toBe('latest');
+    });
+
     it('merges user capabilities at top level', () => {
       const caps = provider.buildCapabilities({
         platform: 'browser',


### PR DESCRIPTION
Resolves #132 

## Proposed changes

The Sauce Labs provider had two issues when building session capabilities:

1. **User-supplied `sauce:options` were silently discarded.** `buildCapabilities()` constructed its own `sauce:options` object from scratch and assigned it, so any `sauce:options` the caller passed via `capabilities` (e.g. `screenResolution`, `extendedDebugging`) never reached the session. Every other top-level user capability was merged — only `sauce:options` was overwritten.

2. **`tunnelName` was set to `undefined` whenever a tunnel was enabled.** When `tunnel: true` (or the legacy `saucelabsLocal`) was set without a `tunnelName`, the provider injected `sauce:options.tunnelName = undefined`, adding a spurious key to the capabilities payload.

This PR fixes both:

- Caller-supplied `sauce:options` are now merged into the generated `sauce:options`. The provider-managed `region` still takes precedence over a user-supplied region so it stays consistent with the connection host.
- `tunnelName` is only set when an actual tunnel name is provided (`saucelabsLocal && options.tunnelName`), so no empty key is emitted.

Unit tests were added in `tests/providers/saucelabs.provider.test.ts` covering: merging user `sauce:options` for both browser and mobile native-app modes, the generated `region` overriding a user-supplied region, and `tunnelName` being omitted both when a tunnel is enabled without a name and when the tunnel is disabled.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have squashed commits that belong together
- [x] I have tested with Claude Desktop (or another MCP-compatible client)
- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added the necessary documentation for new/changed tools (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Further comments

The merge is a shallow spread (`{ ...userSauceOptions, region }`), consistent with how the other top-level user capabilities are already merged in this provider. The provider-owned keys (`region`, and where applicable `build`/`name`/`tunnelName`/`appiumVersion`) intentionally win over user-provided values so the generated session stays internally consistent with the resolved connection config.

### Reviewers: @webdriverio/project-committers
